### PR TITLE
fix(article): GitHub math rendering, critical review, and export improvements

### DIFF
--- a/article/krippendorff-alpha.md
+++ b/article/krippendorff-alpha.md
@@ -29,8 +29,6 @@ article_format:
 
 > **Thesis.** An agreement score of 0.80 among annotators is more likely evidence of structured noise and prevalence than of true consensus when chance agreement is not properly accounted for. Metrics like raw agreement treat overlap as signal; Krippendorff's Alpha models **disagreement** under a randomness benchmark and generalises across raters, missing data, and measurement scales.
 
-**Figures.** This Markdown uses paths `../figures/<name>.png` relative to `article/krippendorff-alpha.md` in the research repository. To produce a folder suitable for another site generator (e.g. a portfolio that runs MD→HTML), use `scripts/export_article_for_portfolio.py`, which rewrites links to `figures/<name>.png` and copies the PNGs next to the exported file.
-
 ---
 
 ## 1. Introduction
@@ -41,19 +39,19 @@ Raw **observed agreement** answers a narrow question: what fraction of comparabl
 
 This matters acutely for **LLM evaluation**. Suppose a workplace pipeline asks humans and a fine-tuned model to assign projects to brand categories. Product and legal teams want a single coefficient: "Do we agree?" If you report only the proportion of agreeing (human, LLM) pairs, a model that shadows the majority class can look excellent while adding no careful judgement. The same pitfall appears in clinical coding, content moderation, and any setting with skewed labels and cost-sensitive errors.
 
-Computational linguistics has relied on agreement coefficients since the era of corpus annotation for parsing and coreference (Artstein and Poesio, 2008). The community's maturity about \(\kappa\) is uneven: leaderboards still mix **accuracy-style** summaries with **prevalence-heavy** tasks. As **foundation models** become default labellers, the question is less "did we hit 80%?" and more "does this automation **track** human exchangeability under the same instructions?" That reframing pushes toward coefficients that tolerate **partial** observation and respect **scale**.
+Computational linguistics has relied on agreement coefficients since the era of corpus annotation for parsing and coreference (Artstein and Poesio, 2008). The community's maturity about $\kappa$ is uneven: leaderboards still mix **accuracy-style** summaries with **prevalence-heavy** tasks. As **foundation models** become default labellers, the question is less "did we hit 80%?" and more "does this automation **track** human exchangeability under the same instructions?" That reframing pushes toward coefficients that tolerate **partial** observation and respect **scale**.
 
 This article follows one narrative arc:
 
 1. Formalise agreement as an **estimator** and separate **signal** from **chance** (Sections 2–3).
-2. Introduce **Cohen's** and **Fleiss'** \(\kappa\) as the standard correction, then show where they **break** (Sections 4–5).
-3. Reframe reliability through **disagreement** and the **coincidence matrix**, leading to **Krippendorff's** \(\alpha\) (Sections 6–7).
+2. Introduce **Cohen's** and **Fleiss'** $\kappa$ as the standard correction, then show where they **break** (Sections 4–5).
+3. Reframe reliability through **disagreement** and the **coincidence matrix**, leading to **Krippendorff's** $\alpha$ (Sections 6–7).
 4. **Validate** the story with four controlled simulations (Section 8).
 5. Close with a **practical decision lens** and honest limits (Sections 9–10).
 
-Notation is fixed throughout: \(K\) categories, \(n\) items (units), \(m\) raters unless stated otherwise. The annotation matrix is \((X_{ij})\) with \(X_{ij} \in \{1,\ldots,K\}\) in this article (code may use zero-based indices). Missing judgments are allowed where noted.
+Notation is fixed throughout: $K$ categories, $n$ items (units), $m$ raters unless stated otherwise. The annotation matrix is $(X_{ij})$ with $X_{ij} \in \{1,\ldots,K\}$ in this article (code may use zero-based indices). Missing judgments are allowed where noted.
 
-The intended reader has met linear algebra and basic probability; no measure-theoretic machinery is required. Proofs of boundary cases for \(\alpha\) are stated at the level of **structure** (what must happen to the coincidence masses) rather than as long epsilon–delta arguments. Where a formula matches the implementation in the companion repository, we point to the phase notes (`notes/phase1-theory.md` through `phase3-alpha.md`) for line-by-line alignment with code.
+The intended reader has met linear algebra and basic probability; no measure-theoretic machinery is required. Proofs of boundary cases for $\alpha$ are stated at the level of **structure** (what must happen to the coincidence masses) rather than as long epsilon–delta arguments. Where a formula matches the implementation in the companion repository, we point to the phase notes (`notes/phase1-theory.md` through `phase3-alpha.md`) for line-by-line alignment with code.
 
 ---
 
@@ -61,44 +59,44 @@ The intended reader has met linear algebra and basic probability; no measure-the
 
 ### 2.1 The annotation problem
 
-We observe a **reliability study**: several raters assign one of \(K\) **nominal** categories to each of \(n\) items. No gold standard is assumed; the goal is to quantify how consistently raters **exchange** the same judgments when faced with the same content. That is **reliability** (replicability of the measurement process), not **validity** (whether categories match the world).
+We observe a **reliability study**: several raters assign one of $K$ **nominal** categories to each of $n$ items. No gold standard is assumed; the goal is to quantify how consistently raters **exchange** the same judgments when faced with the same content. That is **reliability** (replicability of the measurement process), not **validity** (whether categories match the world).
 
 Reliability can be high while validity is poor (everyone applies the same wrong rubric) and vice versa. This article **only** addresses the former: we ask whether the **annotation procedure** is stable across people and, by extension, whether an automated system that mimics those people is aligned with them in a **replicable** sense. Claims about ground truth or downstream utility require additional evidence.
 
 ### 2.2 Pairwise observed agreement
 
-Fix an item \(i\). Let \(S_i\) be the set of unordered rater pairs \((j,\ell)\), \(j<\ell\), such that **both** \(X_{ij}\) and \(X_{i\ell}\) are observed. Define an agreement indicator \(I_{ij\ell} = 1\) if \(X_{ij} = X_{i\ell}\), else \(0\).
+Fix an item $i$. Let $S_i$ be the set of unordered rater pairs $(j,\ell)$, $j<\ell$, such that **both** $X_{ij}$ and $X_{i\ell}$ are observed. Define an agreement indicator $I_{ij\ell} = 1$ if $X_{ij} = X_{i\ell}$, else $0$.
 
 The **observed agreement** is the fraction of comparable pairs that agree:
 
-\[
+$$
 A_o
 =
 \frac{\displaystyle\sum_{i=1}^n \sum_{(j,\ell)\in S_i} I_{ij\ell}}
      {\displaystyle\sum_{i=1}^n |S_i|}.
-\]
+$$
 
-So \(A_o\) is a **sample proportion** of agreeing pairs, pooled over items. It estimates the probability that two randomly drawn **observed** ratings on the **same** item match, under the implicit design that weights each eligible pair equally.
+So $A_o$ is a **sample proportion** of agreeing pairs, pooled over items. It estimates the probability that two randomly drawn **observed** ratings on the **same** item match, under the implicit design that weights each eligible pair equally.
 
-**Worked example (three items, two raters).** Items 1 and 3 agree; item 2 disagrees. Then \(A_o = 2/3\).
+**Worked example (three items, two raters).** Items 1 and 3 agree; item 2 disagrees. Then $A_o = 2/3$.
 
 ### 2.3 Global agreement: pooling judgments with replacement
 
-Some reporting pipelines use an alternative **global** summary: pool all observed judgments, let \(N\) be the pool size and \(n_k\) the count for category \(k\), and imagine drawing **two judgments uniformly at random with replacement** from the pool. The probability both draws equal \(k\) is \((n_k/N)^2\), so
+Some reporting pipelines use an alternative **global** summary: pool all observed judgments, let $N$ be the pool size and $n_k$ the count for category $k$, and imagine drawing **two judgments uniformly at random with replacement** from the pool. The probability both draws equal $k$ is $(n_k/N)^2$, so
 
-\[
+$$
 P(\text{agree}) = \sum_{k=1}^K \Bigl(\frac{n_k}{N}\Bigr)^2.
-\]
+$$
 
-This quantity coincides with the pairwise-within-item \(A_o\) in simple balanced designs but **diverges** when the number of raters varies by item or missingness is uneven. It remains useful as an intuitive "overall overlap" index and matches the \(\sum_k p_k^2\) algebra that reappears in Fleiss' expected agreement \(\bar P_e\). The companion code implements both variants so experiments can be checked against the definition you standardise in your protocol.
+This quantity coincides with the pairwise-within-item $A_o$ in simple balanced designs but **diverges** when the number of raters varies by item or missingness is uneven. It remains useful as an intuitive "overall overlap" index and matches the $\sum_k p_k^2$ algebra that reappears in Fleiss' expected agreement $\bar P_e$. The companion code implements both variants so experiments can be checked against the definition you standardise in your protocol.
 
-### 2.4 What \(A_o\) estimates — and what it misses
+### 2.4 What $A_o$ estimates — and what it misses
 
-\(A_o\) is a transparent **descriptive** statistic. What it is **not** is a calibrated measure of "how much better than chance" the panel behaves. Two independent annotators who each draw labels from a skewed distribution \(\pi\) will still agree with probability \(\sum_k \pi_k^2\), often far above zero. If your reported \(A_o\) is close to that quantity, the data are compatible with **independence**, not with a shared latent truth.
+$A_o$ is a transparent **descriptive** statistic. What it is **not** is a calibrated measure of "how much better than chance" the panel behaves. Two independent annotators who each draw labels from a skewed distribution $\pi$ will still agree with probability $\sum_k \pi_k^2$, often far above zero. If your reported $A_o$ is close to that quantity, the data are compatible with **independence**, not with a shared latent truth.
 
-Like any binomial-style proportion, \(A_o\) has **sampling variability**. Wide items and sparse rare classes can make point estimates noisy; the experiments in Section 8 use \(n=10{,}000\) items partly to make curves visually stable. In applied work, complement point estimates with **confidence intervals** (bootstrap over items is common) and with **disaggregated** views (per-stratum agreement, confusion matrices).
+Like any binomial-style proportion, $A_o$ has **sampling variability**. Wide items and sparse rare classes can make point estimates noisy; the experiments in Section 8 use $n=10{,}000$ items partly to make curves visually stable. In applied work, complement point estimates with **confidence intervals** (bootstrap over items is common) and with **disaggregated** views (per-stratum agreement, confusion matrices).
 
-Hence the framing: treat \(A_o\) as an **estimator** of overlap under your sampling scheme, and always ask what **benchmark** it should be compared to. Section 3 formalises the usual benchmark: **expected agreement under independence** with fixed marginals.
+Hence the framing: treat $A_o$ as an **estimator** of overlap under your sampling scheme, and always ask what **benchmark** it should be compared to. Section 3 formalises the usual benchmark: **expected agreement under independence** with fixed marginals.
 
 ---
 
@@ -106,47 +104,49 @@ Hence the framing: treat \(A_o\) as an **estimator** of overlap under your sampl
 
 ### 3.1 Expected agreement under independence
 
-**Model.** Two annotators assign labels **independently**, each following the same category distribution \(\pi = (\pi_1,\ldots,\pi_K)\), \(\pi_k \ge 0\), \(\sum_k \pi_k = 1\). Then
+**Model.** Two annotators assign labels **independently**, each following the same category distribution $\pi = (\pi_1,\ldots,\pi_K)$, $\pi_k \ge 0$, $\sum_k \pi_k = 1$. Then
 
-\[
+$$
 A_e
 =
 P(\text{both pick the same category})
 =
 \sum_{k=1}^K \pi_k^2.
-\]
+$$
 
-For **uniform** \(\pi_k = 1/K\), we get \(A_e = K \cdot (1/K)^2 = 1/K\). With \(K=2\), independent coin-flip labellers agree half the time **with no shared truth**. With \(K=3\), \(A_e = 1/3\).
+For **uniform** $\pi_k = 1/K$, we get $A_e = K \cdot (1/K)^2 = 1/K$. With $K=2$, independent coin-flip labellers agree half the time **with no shared truth**. With $K=3$, $A_e = 1/3$.
 
-**Imbalanced example.** If \(\pi = (0.7, 0.2, 0.1)\),
+**Imbalanced example.** If $\pi = (0.7, 0.2, 0.1)$,
 
-\[
+$$
 A_e = 0.7^2 + 0.2^2 + 0.1^2 = 0.54.
-\]
+$$
 
 Prevalence alone pushes the independence baseline upward.
 
-| Setting | \(A_e = \sum_k \pi_k^2\) |
+| Setting | $A_e = \sum_k \pi_k^2$ |
 |---------|-------------------------|
-| \(K=2\), uniform | \(0.50\) |
-| \(K=3\), uniform | \(1/3 \approx 0.333\) |
-| \(K=3\), \(\pi=(0.7,0.2,0.1)\) | \(0.54\) |
+| $K=2$, uniform | $0.50$ |
+| $K=3$, uniform | $1/3 \approx 0.333$ |
+| $K=3$, $\pi=(0.7,0.2,0.1)$ | $0.54$ |
 
 The third row is the **warning shot** for applied reports: **more than half** of independent draws would already match even though three categories exist.
 
-### 3.2 Random annotators: why \(A_o\) does not go to zero
+### 3.2 Random annotators: why $A_o$ does not go to zero
 
-Suppose every matrix entry is drawn **independently** from \(\pi\) (no shared latent item truth). Then two ratings on the same item are independent draws from \(\pi\), and the probability they agree is **exactly** \(A_e = \sum_k \pi_k^2 > 0\) for any non-degenerate \(\pi\).
+Suppose every matrix entry is drawn **independently** from $\pi$ (no shared latent item truth). Then two ratings on the same item are independent draws from $\pi$, and the probability they agree is **exactly** $A_e = \sum_k \pi_k^2 > 0$ for any non-degenerate $\pi$.
 
-So **"random" does not mean "zero agreement"**; it means agreement at the **chance** level implied by the marginals. Any headline that cites \(A_o\) without that context risks overstating reliability.
+So **"random" does not mean "zero agreement"**; it means agreement at the **chance** level implied by the marginals. Any headline that cites $A_o$ without that context risks overstating reliability.
 
-### 3.3 Empirical check: convergence to \(\sum_k \pi_k^2\)
+### 3.3 Empirical check: convergence to $\sum_k \pi_k^2$
 
-Phase 1 of the companion codebase simulates **purely random** i.i.d. annotators and tracks \(A_o\) as the number of items grows. The simulation matches the theory: empirical agreement concentrates on \(\sum_k \pi_k^2\). The exercise is deliberately **austere**: there is no latent item difficulty, no instruction drift, and no correlation across raters beyond what independence implies. If real data looked like this simulation, the right conclusion would be that the annotation process carries **no item-specific signal** in the strong sense of the model. Real studies usually violate those assumptions — which is exactly why we need coefficients that **separate** structured agreement from prevalence-driven overlap.
+Phase 1 of the companion codebase simulates **purely random** i.i.d. annotators and tracks $A_o$ as the number of items grows. The simulation matches the theory: empirical agreement concentrates on $\sum_k \pi_k^2$. The exercise is deliberately **austere**: there is no latent item difficulty, no instruction drift, and no correlation across raters beyond what independence implies. If real data looked like this simulation, the right conclusion would be that the annotation process carries **no item-specific signal** in the strong sense of the model. Real studies usually violate those assumptions — which is exactly why we need coefficients that **separate** structured agreement from prevalence-driven overlap.
 
 ![Simulated convergence of observed agreement to the independence baseline under i.i.d. random labelling.](../figures/random_agreement_convergence.png)
 
-**Figure 1.** Random i.i.d. annotators: empirical observed agreement approaches the theoretical expected agreement \(A_e = \sum_k \pi_k^2\) as sample size increases.
+**Figure 1.** Random i.i.d. annotators: empirical observed agreement approaches the theoretical expected agreement $A_e = \sum_k \pi_k^2$ as sample size increases.
+
+The implication is clear: $A_o$ alone cannot distinguish between genuine consensus and prevalence-driven overlap. We need a correction that **subtracts** the chance baseline before interpreting what remains. That is exactly what the Kappa family provides.
 
 ---
 
@@ -154,67 +154,67 @@ Phase 1 of the companion codebase simulates **purely random** i.i.d. annotators 
 
 ### 4.1 The chance-correction pattern
 
-Given an observed agreement \(A_o\) and an expected agreement \(A_e\) under a stated **chance model**, define
+Given an observed agreement $A_o$ and an expected agreement $A_e$ under a stated **chance model**, define
 
-\[
+$$
 \kappa \;=\; \frac{A_o - A_e}{1 - A_e}.
-\]
+$$
 
-When \(A_e < 1\):
+When $A_e < 1$:
 
-- \(\kappa = 1\) if \(A_o = 1\) (perfect overlap).
-- \(\kappa = 0\) if \(A_o = A_e\) (overlap matches the baseline).
-- \(\kappa < 0\) if \(A_o < A_e\) (worse than the baseline).
+- $\kappa = 1$ if $A_o = 1$ (perfect overlap).
+- $\kappa = 0$ if $A_o = A_e$ (overlap matches the baseline).
+- $\kappa < 0$ if $A_o < A_e$ (worse than the baseline).
 
-Different coefficients differ in how \(A_o\) and \(A_e\) are operationalised. The denominator \(1-A_e\) rescales the excess agreement so that \(\kappa\) lives on a **comparable** scale across tasks with different baselines: the same raw gap \(A_o - A_e\) means more when chance agreement was already rare than when it was ubiquitous. That rescaling is intellectually satisfying but also explains why \(\kappa\) can swing dramatically when **small changes** in rare-class counts move \(A_e\): the coefficient is **ratio-based**, not variance-stabilised.
+Different coefficients differ in how $A_o$ and $A_e$ are operationalised. The denominator $1-A_e$ rescales the excess agreement so that $\kappa$ lives on a **comparable** scale across tasks with different baselines: the same raw gap $A_o - A_e$ means more when chance agreement was already rare than when it was ubiquitous. That rescaling is intellectually satisfying but also explains why $\kappa$ can swing dramatically when **small changes** in rare-class counts move $A_e$: the coefficient is **ratio-based**, not variance-stabilised.
 
-### 4.2 Cohen's \(\kappa\) (two fixed raters)
+### 4.2 Cohen's $\kappa$ (two fixed raters)
 
-Two annotators rate the same \(n\) items: \(X_{i1}, X_{i2} \in \{1,\ldots,K\}\).
+Two annotators rate the same $n$ items: $X_{i1}, X_{i2} \in \{1,\ldots,K\}$.
 
 **Observed agreement:**
 
-\[
+$$
 A_o \;=\; \frac{1}{n}\sum_{i=1}^n \mathbf{1}\{X_{i1}=X_{i2}\}.
-\]
+$$
 
-**Expected agreement** uses the **empirical** rater marginals. Let \(p_{k\cdot} = \frac{1}{n}\sum_i \mathbf{1}\{X_{i1}=k\}\) and \(p_{\cdot k} = \frac{1}{n}\sum_i \mathbf{1}\{X_{i2}=k\}\). Under independence with those marginals,
+**Expected agreement** uses the **empirical** rater marginals. Let $p_{k\cdot} = \frac{1}{n}\sum_i \mathbf{1}\{X_{i1}=k\}$ and $p_{\cdot k} = \frac{1}{n}\sum_i \mathbf{1}\{X_{i2}=k\}$. Under independence with those marginals,
 
-\[
+$$
 A_e \;=\; \sum_{k=1}^K p_{k\cdot}\,p_{\cdot k}.
-\]
+$$
 
-**Cohen's kappa:** \(\kappa_C = (A_o - A_e)/(1-A_e)\).
+**Cohen's kappa:** $\kappa_C = (A_o - A_e)/(1-A_e)$.
 
-**Worked \(2\times 2\) example (three items).** With encodings A/B giving \(A_o = 2/3\) and marginals \((2/3, 1/3)\) vs \((1/3, 2/3)\), one obtains \(A_e = 4/9\) and \(\kappa_C = 0.4\).
+**Worked $2\times 2$ example (three items).** With encodings A/B giving $A_o = 2/3$ and marginals $(2/3, 1/3)$ vs $(1/3, 2/3)$, one obtains $A_e = 4/9$ and $\kappa_C = 0.4$.
 
-Cohen's \(\kappa\) is **symmetric** in the two raters for this definition and is widely implemented (e.g. scikit-learn). Its weakness for modern annotation is structural: **only two** fixed individuals, no native slot for "sometimes three crowd workers, sometimes two," and ad hoc handling of missing pairs by **dropping** items. Those limitations are acceptable in classic test–retest studies; they bite in crowdsourcing and LLM–human panels.
+Cohen's $\kappa$ is **symmetric** in the two raters for this definition and is widely implemented (e.g. scikit-learn). Its weakness for modern annotation is structural: **only two** fixed individuals, no native slot for "sometimes three crowd workers, sometimes two," and ad hoc handling of missing pairs by **dropping** items. Those limitations are acceptable in classic test–retest studies; they bite in crowdsourcing and LLM–human panels.
 
-### 4.3 Fleiss' \(\kappa\) (several raters per item)
+### 4.3 Fleiss' $\kappa$ (several raters per item)
 
-There are \(n\) items and \(m\) raters per item (balanced design). For item \(i\), let \(n_{ik}\) be the count of raters who chose category \(k\) (\(\sum_k n_{ik} = m\)).
+There are $n$ items and $m$ raters per item (balanced design). For item $i$, let $n_{ik}$ be the count of raters who chose category $k$ ($\sum_k n_{ik} = m$).
 
-**Extent of agreement on item \(i\):**
+**Extent of agreement on item $i$:**
 
-\[
+$$
 P_i \;=\; \frac{1}{m(m-1)}\sum_{k=1}^K n_{ik}(n_{ik}-1),
-\]
+$$
 
-the fraction of **unordered** rater pairs on item \(i\) that agree.
+the fraction of **unordered** rater pairs on item $i$ that agree.
 
-**Mean observed agreement:** \(\bar P = \frac{1}{n}\sum_i P_i\).
+**Mean observed agreement:** $\bar P = \frac{1}{n}\sum_i P_i$.
 
-**Pooled category proportions:** \(p_k = \frac{1}{nm}\sum_i n_{ik}\).
+**Pooled category proportions:** $p_k = \frac{1}{nm}\sum_i n_{ik}$.
 
-**Expected agreement:** \(\bar P_e = \sum_k p_k^2\) (same functional form as Section 3 when all judgments share one marginal).
+**Expected agreement:** $\bar P_e = \sum_k p_k^2$ (same functional form as Section 3 when all judgments share one marginal).
 
-**Fleiss' kappa:** \(\kappa_F = (\bar P - \bar P_e)/(1 - \bar P_e)\).
+**Fleiss' kappa:** $\kappa_F = (\bar P - \bar P_e)/(1 - \bar P_e)$.
 
-**Tiny sanity check (\(n=2\) items, \(m=3\) raters, \(K=2\)).** Item 1 with label counts \((2,1)\) gives \(P_1 = (2\cdot 1 + 1\cdot 0)/(3\cdot 2) = 1/3\). Item 2 with counts \((0,3)\) gives \(P_2 = 1\). Hence \(\bar P = (1/3 + 1)/2 = 2/3\). Pooling six judgments yields \(p_0 = 1/3\), \(p_1 = 2/3\), so \(\bar P_e = (1/3)^2 + (2/3)^2 = 5/9\) and \(\kappa_F = (2/3 - 5/9)/(1 - 5/9) = (1/9)/(4/9) = 0.25\). The hand calculation matches the unit tests in the codebase — a useful anchor when debugging new simulation pipelines.
+**Tiny sanity check ($n=2$ items, $m=3$ raters, $K=2$).** Item 1 with label counts $(2,1)$ gives $P_1 = (2\cdot 1 + 1\cdot 0)/(3\cdot 2) = 1/3$. Item 2 with counts $(0,3)$ gives $P_2 = 1$. Hence $\bar P = (1/3 + 1)/2 = 2/3$. Pooling six judgments yields $p_0 = 1/3$, $p_1 = 2/3$, so $\bar P_e = (1/3)^2 + (2/3)^2 = 5/9$ and $\kappa_F = (2/3 - 5/9)/(1 - 5/9) = (1/9)/(4/9) = 0.25$. The hand calculation matches the unit tests in the codebase — a useful anchor when debugging new simulation pipelines.
 
 ### 4.4 Why Kappa helps
 
-Both \(\kappa_C\) and \(\kappa_F\) **re-express** overlap relative to a **data-driven** chance baseline. When \(A_o\) is high only because \(\bar P_e\) is high, \(\kappa_F\) moves toward zero, signalling that apparent harmony is largely **prevalence-driven**. That is the right direction for interpretation — until the baseline and structural assumptions themselves become inadequate (Section 5).
+Both $\kappa_C$ and $\kappa_F$ **re-express** overlap relative to a **data-driven** chance baseline. When $A_o$ is high only because $\bar P_e$ is high, $\kappa_F$ moves toward zero, signalling that apparent harmony is largely **prevalence-driven**. That is the right direction for interpretation — until the baseline and structural assumptions themselves become inadequate (Section 5).
 
 ---
 
@@ -222,27 +222,27 @@ Both \(\kappa_C\) and \(\kappa_F\) **re-express** overlap relative to a **data-d
 
 ### 5.1 The Kappa paradox
 
-When one category is **very prevalent**, independent raters still agree often because \(\bar P_e = \sum_k p_k^2\) is dominated by \(p_{\text{major}}^2\). A high **raw** agreement can therefore coexist with **low** \(\kappa\): the coefficient is doing its job, but readers who only track \(A_o\) feel a **paradox**.
+When one category is **very prevalent**, independent raters still agree often because $\bar P_e = \sum_k p_k^2$ is dominated by $p_{\text{major}}^2$. A high **raw** agreement can therefore coexist with **low** $\kappa$: the coefficient is doing its job, but readers who only track $A_o$ feel a **paradox**.
 
-Clinicians have long documented **"high agreement but low kappa"** scenarios (Feinstein and Cicchetti, 1990): the statistical structure is the same **prevalence inflation** of the chance baseline. The paradox is not a quirk of one subfield — it is the predictable algebra of \(\sum_k p_k^2\) when one \(p_k\) nears one.
+Clinicians have long documented **"high agreement but low kappa"** scenarios (Feinstein and Cicchetti, 1990): the statistical structure is the same **prevalence inflation** of the chance baseline. The paradox is not a quirk of one subfield — it is the predictable algebra of $\sum_k p_k^2$ when one $p_k$ nears one.
 
-The companion codebase sweeps imbalance at fixed noise; Fleiss' \(\kappa\) can sit far below raw agreement while \(A_o\) stays in the "excellent" band on naive scales. The figure is not a proof; it is a **visual reminder** that **ranking models** by raw agreement can invert a ranking by \(\kappa_F\) when class balance differs across conditions.
+The companion codebase sweeps imbalance at fixed noise; Fleiss' $\kappa$ can sit far below raw agreement while $A_o$ stays in the "excellent" band on naive scales. The figure is not a proof; it is a **visual reminder** that **ranking models** by raw agreement can invert a ranking by $\kappa_F$ when class balance differs across conditions.
 
 ![Fleiss' kappa versus class imbalance at fixed annotation noise (Kappa paradox).](../figures/kappa_paradox.png)
 
-**Figure 2.** As the majority-class mass grows, expected agreement under independence grows with it; \(\kappa_F\) can fall sharply even when naive overlap remains high.
+**Figure 2.** As the majority-class mass grows, expected agreement under independence grows with it; $\kappa_F$ can fall sharply even when naive overlap remains high.
 
 ### 5.2 Structural constraints
 
 | Limitation | Cohen | Fleiss |
 |------------|-------|--------|
-| Number of raters | Exactly **two** | Same \(m \ge 2\) for every item |
+| Number of raters | Exactly **two** | Same $m \ge 2$ for every item |
 | Missing data | Not native | **Complete** matrix typically required |
 | Scale | **Nominal** | **Nominal** (weighted variants exist) |
 
-Ordinal, interval, and ratio data can be squeezed into nominal bins or **weighted** \(\kappa\), but there is no single Kappa object that natively carries **metric** distances between categories while handling **variable** numbers of judgments and **missing** cells in one framework.
+Ordinal, interval, and ratio data can be squeezed into nominal bins or **weighted** $\kappa$, but there is no single Kappa object that natively carries **metric** distances between categories while handling **variable** numbers of judgments and **missing** cells in one framework.
 
-### 5.3 Building the case for \(\alpha\)
+### 5.3 Building the case for $\alpha$
 
 We need a coefficient that:
 
@@ -250,21 +250,60 @@ We need a coefficient that:
 2. Allows **missing** ratings without discarding entire items arbitrarily.
 3. Supports **distances** between values (ordinal steps, squared interval gaps, ratio penalties).
 
-Krippendorff's \(\alpha\) is built for that role. It does not erase the need for careful **study design**: if instructions are ambiguous, no coefficient will rescue interpretability. What \(\alpha\) offers is a **single algebraic skeleton** that extends from nominal through ratio scales and respects **pairable** information only — the same philosophical move as using **effective sample sizes** in other parts of statistics.
+Krippendorff's $\alpha$ is built for that role. It does not erase the need for careful **study design**: if instructions are ambiguous, no coefficient will rescue interpretability. What $\alpha$ offers is a **single algebraic skeleton** that extends from nominal through ratio scales and respects **pairable** information only — the same philosophical move as using **effective sample sizes** in other parts of statistics.
 
 ---
 
 ## 6. From agreement to disagreement
 
-Raw agreement and Kappa-style numerators count **matches**. An equivalent dual view counts **mismatches** weighted by how far apart categories are. For nominal data, "distance" is binary: same or not. For interval data, squared differences penalise large errors more.
+### 6.1 Why shift the lens
 
-Krippendorff's construction starts from a **reliability matrix**: rows are **units** (items), columns are **raters**, entries are values (categories or numeric scores). Missing entries are **excluded**; only pairs of distinct raters on the same unit contribute.
+Raw agreement and Kappa-style numerators count **matches**: how many pairs gave the same label? An equivalent dual view counts **mismatches** weighted by how far apart the assigned categories are. For nominal data, "distance" is binary — same or not. For interval data, squared differences penalise large errors more than small ones. This dual view turns out to be more general: it naturally accommodates **measurement scales** beyond the nominal and leads to a single formula that unifies all cases.
 
-The **coincidence matrix** \(\mathbf{O}\) aggregates how often values **co-occur** on different raters of the same unit, with a normalisation that fixes the **marginal exposure** of each category. From \(\mathbf{O}\) one builds an **expected** coincidence matrix \(\mathbf{E}\) under a null that **randomly re-pairs** judgments while preserving those marginals. **Disagreement** is then a weighted sum of entries of \(\mathbf{O}\) and \(\mathbf{E}\) against a **distance matrix** \(\mathbf{D}\).
+### 6.2 The reliability matrix
 
-Think of each unit as a small **multiset** of judgments. Every unordered pair of **distinct raters** on that unit contributes one "draw" of an ordered pair of values \((v, v')\). The coincidence construction **counts** how often each \((v, v')\) arises, weighted so that units with more raters do not automatically dominate the total mass. Missingness simply **shrinks** the multiset: a unit with one label cannot contribute pair information.
+Krippendorff's construction starts from a **reliability matrix**: rows are **units** (items), columns are **raters**, entries are values (categories or numeric scores). Missing entries are **excluded** from all calculations; only pairs of distinct raters on the same unit contribute information. A unit with a single observed label cannot form a pair and is silently dropped — no imputation, no row deletion.
 
-The conceptual shift is simple: instead of "how often do we agree?", ask **"how much farther apart are we than random pairing would predict?"** Agreement is the special case in which distance is zero on the diagonal and one elsewhere (nominal \(\delta\)).
+### 6.3 Building the coincidence matrix — a worked example
+
+Consider three items rated by three annotators on a binary domain $\{A, B\}$:
+
+| Unit | Rater 1 | Rater 2 | Rater 3 |
+|------|---------|---------|---------|
+| 1    | A       | A       | B       |
+| 2    | B       | B       | —       |
+| 3    | A       | A       | A       |
+
+**Step 1 — count vectors.** For each unit, count how many times each value appears among **observed** ratings:
+
+- Unit 1: $\mathbf{n}_1 = (2, 1)$, with $m_1 = 3$ raters.
+- Unit 2: $\mathbf{n}_2 = (0, 2)$, with $m_2 = 2$ raters (Rater 3 is missing).
+- Unit 3: $\mathbf{n}_3 = (3, 0)$, with $m_3 = 3$ raters.
+
+**Step 2 — local coincidence contributions.** For each unit, the contribution to the coincidence matrix is proportional to how often pairs of **distinct** raters assigned each combination of values. For a unit with count vector $\mathbf{n}_i$, the off-diagonal entry $(c, c')$ receives $n_{ic} \cdot n_{ic'}/(m_i - 1)$, and the diagonal entry $(c, c)$ receives $n_{ic}(n_{ic} - 1)/(m_i - 1)$. The denominator $m_i - 1$ ensures that each unit contributes **one unit of total mass** regardless of how many raters observed it.
+
+Applying this to our example:
+
+- **Unit 1** ($m_1 = 3$): diagonal $(A,A) = 2 \cdot 1 / 2 = 1$; diagonal $(B,B) = 1 \cdot 0 / 2 = 0$; off-diagonal $(A,B) = 2 \cdot 1 / 2 = 1$.
+- **Unit 2** ($m_2 = 2$): diagonal $(B,B) = 2 \cdot 1 / 1 = 2$; all other entries zero.
+- **Unit 3** ($m_3 = 3$): diagonal $(A,A) = 3 \cdot 2 / 2 = 3$; all other entries zero.
+
+**Step 3 — sum to get $\mathbf{O}$.** Add the contributions across units:
+
+|       | A   | B   |
+|-------|-----|-----|
+| **A** | 4   | 1   |
+| **B** | 1   | 2   |
+
+The marginals are $n_A = 5$, $n_B = 3$, and the total pairable mass is $N = 8$.
+
+**Step 4 — expected coincidence $\mathbf{E}$.** Under the null hypothesis that pairs are formed by random re-pairing of the same marginal totals, the expected matrix entries are $E_{cc'} = (n_c n_{c'} - n_c \delta_{cc'}) / (N - 1)$. For instance, $E_{AB} = (5 \cdot 3) / 7 \approx 2.14$ and $E_{AA} = (5 \cdot 4) / 7 \approx 2.86$.
+
+### 6.4 From coincidence to disagreement
+
+The **observed disagreement** is the weighted sum $D_o^* = \sum_{c,c'} O_{cc'} D_{cc'}$, where $D_{cc'} = \delta(c, c')$ encodes distance. The **expected disagreement** $D_e^*$ uses $\mathbf{E}$ in the same formula. The ratio $D_o^* / D_e^*$ tells us how the panel's actual pattern of mismatches compares to what random pairing would produce.
+
+The conceptual shift is simple: instead of "how often do we agree?", ask **"how much farther apart are we than random pairing would predict?"** Agreement is the special case in which distance is zero on the diagonal and one elsewhere (nominal $\delta$). Section 7 assembles these pieces into the full $\alpha$ formula.
 
 ---
 
@@ -272,142 +311,144 @@ The conceptual shift is simple: instead of "how often do we agree?", ask **"how 
 
 ### 7.1 Definition
 
-Let \(\delta(c,c')\) be a **metric** between category values (nominal, ordinal, interval, ratio — see below). Let \(\mathbf{D}\) have entries \(D_{cc'} = \delta(v_c, v_{c'})\) on an ordered value domain \((v_1,\ldots,v_V)\).
+Let $\delta(c,c')$ be a **metric** between category values (nominal, ordinal, interval, ratio — see below). Let $\mathbf{D}$ have entries $D_{cc'} = \delta(v_c, v_{c'})$ on an ordered value domain $(v_1,\ldots,v_V)$.
 
-From the data, build the **observed coincidence matrix** \(\mathbf{O}\) (symmetric, nonnegative) and the **expected** matrix \(\mathbf{E}\) under the random-pairing null that preserves marginal totals derived from \(\mathbf{O}\). Define scalar disagreements
+From the data, build the **observed coincidence matrix** $\mathbf{O}$ (symmetric, nonnegative) and the **expected** matrix $\mathbf{E}$ under the random-pairing null that preserves marginal totals derived from $\mathbf{O}$. Define scalar disagreements
 
-\[
+$$
 D_o^\* = \sum_{c,c'} O_{cc'}\,D_{cc'},
 \qquad
 D_e^\* = \sum_{c,c'} E_{cc'}\,D_{cc'}.
-\]
+$$
 
 **Krippendorff's alpha** is
 
-\[
+$$
 \alpha = 1 - \frac{D_o^\*}{D_e^\*}.
-\]
+$$
 
-When \(D_e^\*\) is zero (degenerate case), \(\alpha\) is not defined as a finite ratio.
+When $D_e^\*$ is zero (degenerate case), $\alpha$ is not defined as a finite ratio.
 
-### 7.2 Building \(\mathbf{O}\) (sketch)
+### 7.2 Building $\mathbf{O}$ (sketch)
 
-For each unit \(i\) with \(m_i \ge 2\) observed judgments, form the count vector \(\mathbf{n}_i = (n_{i1},\ldots,n_{iV})\) of how many raters used each domain value. Unnormalised co-occurrence is related to \(\mathbf{n}_i\mathbf{n}_i^\top\) with the diagonal adjusted so self-pairs from the **same** rater do not count. Scale by \(1/(m_i-1)\) and sum over units. **Missing** raters are dropped before forming \(\mathbf{n}_i\); no pair is formed with a missing cell.
+For each unit $i$ with $m_i \ge 2$ observed judgments, form the count vector $\mathbf{n}_i = (n_{i1},\ldots,n_{iV})$ of how many raters used each domain value. Unnormalised co-occurrence is related to $\mathbf{n}_i\mathbf{n}_i^\top$ with the diagonal adjusted so self-pairs from the **same** rater do not count. Scale by $1/(m_i-1)$ and sum over units. **Missing** raters are dropped before forming $\mathbf{n}_i$; no pair is formed with a missing cell.
 
-Concretely, for a single unit with three raters and counts \((2,1,0)\) on domain \((v_1,v_2,v_3)\), the adjustment subtracts rater self-pairs from the outer product of counts, then divides by \(m_i-1\). The resulting local matrix contributes off-diagonal mass where **cross-category** pairings occur; the diagonal records **within-category** pairings that survive the subtraction. Summing these contributions over **all** units yields \(\mathbf{O}\). The implementation in the repository follows Krippendorff (2004) and is cross-checked against the `krippendorff` Python package on reference reliability matrices.
+Concretely, for a single unit with three raters and counts $(2,1,0)$ on domain $(v_1,v_2,v_3)$, the adjustment subtracts rater self-pairs from the outer product of counts, then divides by $m_i-1$. The resulting local matrix contributes off-diagonal mass where **cross-category** pairings occur; the diagonal records **within-category** pairings that survive the subtraction. Summing these contributions over **all** units yields $\mathbf{O}$. The implementation in the repository follows Krippendorff (2004) and is cross-checked against the `krippendorff` Python package on reference reliability matrices.
 
 ### 7.3 Expected coincidence
 
-Let \(n_c\) be marginals derived from \(\mathbf{O}\) and \(N = \sum_c n_c\) the total pairable mass. Under the standard null,
+Let $n_c$ be marginals derived from $\mathbf{O}$ and $N = \sum_c n_c$ the total pairable mass. Under the standard null,
 
-\[
+$$
 E_{cc'} = \frac{n_c n_{c'} - n_c\,\delta_{cc'}}{N-1},
-\]
+$$
 
 symmetric and aligned with sampling-without-replacement intuition on pair slots.
 
 ### 7.4 Distance functions
 
-- **Nominal:** \(\delta(c,c') = 0\) if \(c=c'\), else \(1\).
-- **Interval:** \((c-c')^2\).
-- **Ratio:** \(\bigl((c-c')/(c+c')\bigr)^2\) (with convention at \(c+c'=0\)).
+- **Nominal:** $\delta(c,c') = 0$ if $c=c'$, else $1$.
+- **Interval:** $(c-c')^2$.
+- **Ratio:** $\bigl((c-c')/(c+c')\bigr)^2$ (with convention at $c+c'=0$).
 - **Ordinal:** uses the ordered domain and category masses (not plain rank gaps without weights); see Krippendorff (2004, Ch. 11).
 
 ### 7.5 Boundary behaviour
 
-Assume \(D_e^\* > 0\).
+Assume $D_e^\* > 0$.
 
-- **Perfect reliability** (for nominal \(\delta\), all pairable judgments on a unit coincide): off-diagonal mass vanishes appropriately, \(D_o^\* = 0\), hence \(\alpha = 1\).
-- **Chance-level** disagreement: \(D_o^\* = D_e^\*\) implies \(\alpha = 0\).
-- **Systematic** disagreement beyond the null: \(D_o^\* > D_e^\*\) implies \(\alpha < 0\).
+- **Perfect reliability** (for nominal $\delta$, all pairable judgments on a unit coincide): off-diagonal mass vanishes appropriately, $D_o^\* = 0$, hence $\alpha = 1$.
+- **Chance-level** disagreement: $D_o^\* = D_e^\*$ implies $\alpha = 0$.
+- **Systematic** disagreement beyond the null: $D_o^\* > D_e^\*$ implies $\alpha < 0$.
 
-**Reading \(\alpha\) as a scaled excess.** When \(D_e^\* > 0\), rearrange \(\alpha = 1 - D_o^\*/D_e^\*\) as
+**Reading $\alpha$ as a scaled excess.** When $D_e^\* > 0$, rearrange $\alpha = 1 - D_o^\*/D_e^\*$ as
 
-\[
+$$
 \alpha = \frac{D_e^\* - D_o^\*}{D_e^\*}.
-\]
+$$
 
-So \(\alpha\) is the **fractional reduction** of observed disagreement relative to the expected matrix under the null — analogous in spirit to how \(\kappa\) expresses excess agreement relative to \(1-A_e\), but built on **metric** weights rather than a single scalar \(A_o\). Negative \(\alpha\) means the pattern of weighted distances is **more discordant** than random pairing would predict under fixed exposure, a warning sign of **systematic** divergence (ambiguous guidelines, adversarial items, or instrument drift).
+So $\alpha$ is the **fractional reduction** of observed disagreement relative to the expected matrix under the null — analogous in spirit to how $\kappa$ expresses excess agreement relative to $1-A_e$, but built on **metric** weights rather than a single scalar $A_o$. Negative $\alpha$ means the pattern of weighted distances is **more discordant** than random pairing would predict under fixed exposure, a warning sign of **systematic** divergence (ambiguous guidelines, adversarial items, or instrument drift).
 
-### 7.6 Relation to Cohen's \(\kappa\)
+### 7.6 Relation to Cohen's $\kappa$
 
-Cohen's \(\kappa\) uses **per-rater** marginals on the same items. Krippendorff's \(\alpha\) uses **pooled** coincidence marginals from \(\mathbf{O}\). For **two** raters and **nominal** data, both correct for chance, but the **numerical value** need not equal \(\kappa_C\) when \(K>2\): the chance models differ. In practice, report **one** coefficient and stick to its interpretation, or compare both explicitly in a sensitivity table.
+Cohen's $\kappa$ uses **per-rater** marginals on the same items. Krippendorff's $\alpha$ uses **pooled** coincidence marginals from $\mathbf{O}$. For **two** raters and **nominal** data, both correct for chance, but the **numerical value** need not equal $\kappa_C$ when $K>2$: the chance models differ. In practice, report **one** coefficient and stick to its interpretation, or compare both explicitly in a sensitivity table.
 
 ### 7.7 Software and reproducibility
 
-The article's claims about \(\alpha\) are backed by `krippendorff_alpha()` in the companion package, validated against published examples and the reference library. **Nominal**, **interval**, **ratio**, and **ordinal** levels are implemented with explicit **value domains** so that unused categories do not distort distances. When you port formulas into another language, the fragile details are usually the **ordinal** weights and the treatment of **all-missing** units — test against the reference package before trusting edge cases.
+The article's claims about $\alpha$ are backed by `krippendorff_alpha()` in the companion package, validated against published examples and the reference library. **Nominal**, **interval**, **ratio**, and **ordinal** levels are implemented with explicit **value domains** so that unused categories do not distort distances. When you port formulas into another language, the fragile details are usually the **ordinal** weights and the treatment of **all-missing** units — test against the reference package before trusting edge cases.
 
 ### 7.8 Ordinal and interval scales in practice
 
-For **interval** ratings (e.g. 1–5 Likert), squaring differences in \(\delta\) penalises **large** jumps more harshly than small ones — a natural match when errors farther apart are substantively worse. For **ordinal** labels, Krippendorff's construction uses the empirical totals \(n_v\) to weight distances between **steps** on the ordered domain; this avoids the mistake of treating ordered categories as if they were equally spaced numbers unless your measurement theory supports that identification. In **NLP**, many "scales" are ordinal by design (fine-grained sentiment buckets); reporting **nominal** \(\alpha\) on those buckets is conservative with respect to order information, while **ordinal** \(\alpha\) uses more structure and therefore demands **defensible** spacing assumptions encoded in the value domain.
+For **interval** ratings (e.g. 1–5 Likert), squaring differences in $\delta$ penalises **large** jumps more harshly than small ones — a natural match when errors farther apart are substantively worse. For **ordinal** labels, Krippendorff's construction uses the empirical totals $n_v$ to weight distances between **steps** on the ordered domain; this avoids the mistake of treating ordered categories as if they were equally spaced numbers unless your measurement theory supports that identification. In **NLP**, many "scales" are ordinal by design (fine-grained sentiment buckets); reporting **nominal** $\alpha$ on those buckets is conservative with respect to order information, while **ordinal** $\alpha$ uses more structure and therefore demands **defensible** spacing assumptions encoded in the value domain.
+
+With the definition, construction, and boundary properties of $\alpha$ in place, the next step is empirical: do these properties hold in controlled simulations, and how does $\alpha$ compare to $A_o$ and $\kappa_F$ when we can compute ground-truth expectations?
 
 ---
 
 ## 8. Experiments
 
-Four simulations (Phase 4 of the codebase) isolate properties of \(A_o\), \(\kappa_F\), and \(\alpha\). All use **fixed seeds** and are reproducible via `make experiments` or the individual `scripts/experiment_*.py` commands.
+Four simulations (Phase 4 of the codebase) isolate properties of $A_o$, $\kappa_F$, and $\alpha$. All use **fixed seeds** and are reproducible via `make experiments` or the individual `scripts/experiment_*.py` commands.
 
 They are **synthetic** on purpose: closed-form targets exist for random labelling, and grids over noise and imbalance are cheap to repeat. Translating the qualitative lessons to a live LLM API requires additional layers (calibration, adversarial prompts, human factors) that fall outside this draft — but the **algebraic** pitfalls of raw agreement and the **structural** limits of Fleiss remain.
 
 ### 8.1 Experiment A: random annotators
 
-**Setup.** Pure i.i.d. labelling (`pure_random=True`), uniform categories, noise-free independence. Sweep \(K \in \{2,\ldots,10\}\) with \(n=10{,}000\), \(m=5\).
+**Setup.** Pure i.i.d. labelling (`pure_random=True`), uniform categories, noise-free independence. Sweep $K \in \{2,\ldots,10\}$ with $n=10{,}000$, $m=5$.
 
-**Expectation.** \(A_o \approx 1/K\); \(\kappa_F \approx 0\); \(\alpha \approx 0\).
+**Expectation.** $A_o \approx 1/K$; $\kappa_F \approx 0$; $\alpha \approx 0$.
 
-**Result.** Empirical curves match theory within tight tolerance; for \(K=3\), all three metrics sit near the predicted baseline. This is the **sanity check** that chance-corrected coefficients vanish when there is no shared structure beyond independence.
+**Result.** Empirical curves match theory within tight tolerance; for $K=3$, all three metrics sit near the predicted baseline. This is the **sanity check** that chance-corrected coefficients vanish when there is no shared structure beyond independence.
 
-The sweep over \(K\) also illustrates a **presentation hazard**: if you only report \(A_o\) and vary the number of categories between studies, the **raw** scale moves with \(1/K\) even when behaviour is "maximally uninformative" in the \(\kappa/\alpha\) sense. Normalising by the independence baseline — what Kappa and \(\alpha\) encode differently — is not optional for cross-study comparison.
+The sweep over $K$ also illustrates a **presentation hazard**: if you only report $A_o$ and vary the number of categories between studies, the **raw** scale moves with $1/K$ even when behaviour is "maximally uninformative" in the $\kappa/\alpha$ sense. Normalising by the independence baseline — what Kappa and $\alpha$ encode differently — is not optional for cross-study comparison.
 
-![Experiment A: \(A_o\), Fleiss' \(\kappa_F\), and Krippendorff's \(\alpha\) across \(K\) for random i.i.d. raters.](../figures/exp_a_random_metrics.png)
+![Experiment A: $A_o$, Fleiss' $\kappa_F$, and Krippendorff's $\alpha$ across $K$ for random i.i.d. raters.](../figures/exp_a_random_metrics.png)
 
-**Figure 3.** Random annotators: observed agreement tracks \(1/K\); \(\kappa_F\) and \(\alpha\) track zero.
+**Figure 3.** Random annotators: observed agreement tracks $1/K$; $\kappa_F$ and $\alpha$ track zero.
 
 ### 8.2 Experiment B: high agreement trap
 
-**Setup.** Severe class skew (several latent \(\pi\) presets) and low annotation noise on a five-rater panel. Grid over imbalance and \(\varepsilon\).
+**Setup.** Severe class skew (several latent $\pi$ presets) and low annotation noise on a five-rater panel. Grid over imbalance and $\varepsilon$.
 
-**Expectation.** Regions where **raw** \(A_o\) stays high but \(\alpha\) (and \(\kappa_F\)) fall — the **trap** central to the thesis.
+**Expectation.** Regions where **raw** $A_o$ stays high but $\alpha$ (and $\kappa_F$) fall — the **trap** central to the thesis.
 
-**Result.** Heatmaps of \(A_o\) and \(\alpha\) show a visible wedge where \(A_o > 0.8\) while \(\alpha < 0.4\). A spotlight table (script output) pairs a concrete \((\pi, \varepsilon)\) with numeric \(A_o\), \(\kappa_F\), and \(\alpha\) for direct quotation in prose.
+**Result.** Heatmaps of $A_o$ and $\alpha$ show a visible wedge where $A_o > 0.8$ while $\alpha < 0.4$. A spotlight table (script output) pairs a concrete $(\pi, \varepsilon)$ with numeric $A_o$, $\kappa_F$, and $\alpha$ for direct quotation in prose.
 
 This is the article's **hero pattern**: stakeholders see a **comfortable** raw percentage while the chance-corrected coefficients whisper that the panel is only modestly better than a prevalence-aware random benchmark. The rhetorical lesson is operational: put **both** views in the same table by default, not in an appendix.
 
-![Experiment B: heatmaps of \(\alpha\) and \(A_o\) over imbalance and noise; red boxes mark the trap region.](../figures/exp_b_agreement_trap_heatmap.png)
+![Experiment B: heatmaps of $\alpha$ and $A_o$ over imbalance and noise; red boxes mark the trap region.](../figures/exp_b_agreement_trap_heatmap.png)
 
 **Figure 4.** Agreement trap: high raw overlap coexists with low chance-corrected reliability under skew + low noise.
 
 ### 8.3 Experiment C: LLM versus humans (synthetic)
 
-**Setup.** Three "human" annotators with noise \(\varepsilon = 0.10\) and one "LLM" annotator with \(\varepsilon = 0.15\) on a three-class task; sensitivity over LLM noise in \([0, 0.5]\).
+**Setup.** Three "human" annotators with noise $\varepsilon = 0.10$ and one "LLM" annotator with $\varepsilon = 0.15$ on a three-class task; sensitivity over LLM noise in $[0, 0.5]$.
 
-**Metrics.** Observed agreement, Fleiss' \(\kappa\) on the full panel, \(\alpha\) on humans-only vs full panel, and pairwise Cohen's \(\kappa\) between each human and the LLM column.
+**Metrics.** Observed agreement, Fleiss' $\kappa$ on the full panel, $\alpha$ on humans-only vs full panel, and pairwise Cohen's $\kappa$ between each human and the LLM column.
 
-**Result.** \(\alpha\) and related summaries **track** panel quality; adding a noisier rater tends to **reduce** panel \(\alpha\) relative to humans-only. The sensitivity curve makes the dose–response visible for the synthetic noise parameter (a stand-in for model quality, not a claim about a specific API).
+**Result.** $\alpha$ and related summaries **track** panel quality; adding a noisier rater tends to **reduce** panel $\alpha$ relative to humans-only. The sensitivity curve makes the dose–response visible for the synthetic noise parameter (a stand-in for model quality, not a claim about a specific API).
 
-Pairwise Cohen \(\kappa\) between each human and the LLM column gives a **local** picture; Fleiss on the full matrix answers a **global** panel question. None of these numbers replace **error analysis** on disagreements, but together they prevent a single proportion from monopolising the narrative.
+Pairwise Cohen $\kappa$ between each human and the LLM column gives a **local** picture; Fleiss on the full matrix answers a **global** panel question. None of these numbers replace **error analysis** on disagreements, but together they prevent a single proportion from monopolising the narrative.
 
-![Experiment C: sensitivity of \(\alpha\) to synthetic LLM noise; humans-only vs full panel.](../figures/exp_c_llm_vs_humans.png)
+![Experiment C: sensitivity of $\alpha$ to synthetic LLM noise; humans-only vs full panel.](../figures/exp_c_llm_vs_humans.png)
 
-**Figure 5.** Synthetic LLM vs humans: \(\alpha\) responds to injected LLM noise; compare humans-only to full panel.
+**Figure 5.** Synthetic LLM vs humans: $\alpha$ responds to injected LLM noise; compare humans-only to full panel.
 
 ### 8.4 Experiment D: missing data
 
 **Setup.** Fixed balanced panel with moderate noise; inject MCAR missingness from 0% to 50%.
 
-**Expectation.** Fleiss' formulation (complete matrix) becomes **undefined** or **NaN** once entries are missing; \(\alpha\) **degrades gracefully** because it is defined on pairable units.
+**Expectation.** Fleiss' formulation (complete matrix) becomes **undefined** or **NaN** once entries are missing; $\alpha$ **degrades gracefully** because it is defined on pairable units.
 
-**Result.** \(\alpha\) remains stable near its complete-data value while Fleiss drops out — a practical reason to prefer \(\alpha\) in sparse annotation regimes.
+**Result.** $\alpha$ remains stable near its complete-data value while Fleiss drops out — a practical reason to prefer $\alpha$ in sparse annotation regimes.
 
-Real annotators quit mid-batch, merge requests split reviewer pools, and LLM calls time out. A metric that requires **imputation** or **row deletion** to return a number invites silent bias. \(\alpha\)'s pairwise coincidence logic is not magic — if missingness is **informative**, no coefficient is safe — but it avoids **structural** failure modes of complete-case Fleiss.
+Real annotators quit mid-batch, merge requests split reviewer pools, and LLM calls time out. A metric that requires **imputation** or **row deletion** to return a number invites silent bias. $\alpha$'s pairwise coincidence logic is not magic — if missingness is **informative**, no coefficient is safe — but it avoids **structural** failure modes of complete-case Fleiss.
 
-![Experiment D: \(\alpha\) vs Fleiss' \(\kappa\) as missing rate increases.](../figures/exp_d_missing_robustness.png)
+![Experiment D: $\alpha$ vs Fleiss' $\kappa$ as missing rate increases.](../figures/exp_d_missing_robustness.png)
 
-**Figure 6.** Missing data: \(\alpha\) stays informative; Fleiss requires a complete matrix.
+**Figure 6.** Missing data: $\alpha$ stays informative; Fleiss requires a complete matrix.
 
 ### 8.5 Synthesis
 
-Together, the experiments support the thesis: **raw agreement misleads** under independence and skew; **Kappa** partially corrects but inherits structural limits; **\(\alpha\)** handles missingness and unifies disagreement-based thinking — validated here on synthetic ground truth where expectations are analytic or visually clear.
+Together, the experiments support the thesis: **raw agreement misleads** under independence and skew; **Kappa** partially corrects but inherits structural limits; **$\alpha$** handles missingness and unifies disagreement-based thinking — validated here on synthetic ground truth where expectations are analytic or visually clear.
 
 ---
 
@@ -415,10 +456,10 @@ Together, the experiments support the thesis: **raw agreement misleads** under i
 
 ### 9.1 When to use which metric
 
-- **Report \(A_o\)** as a **transparent** prevalence-sensitive summary, **always** alongside a chance-aware coefficient.
-- **Cohen's \(\kappa\)** when there are **exactly two** fixed raters, **complete** data, and **nominal** (or weighted) categories.
-- **Fleiss' \(\kappa\)** when every item has the **same** number of raters and the matrix is **complete**.
-- **Krippendorff's \(\alpha\)** when you have **missing** judgments, **variable** numbers of raters per unit, or you need **ordinal/interval/ratio** distances in one framework.
+- **Report $A_o$** as a **transparent** prevalence-sensitive summary, **always** alongside a chance-aware coefficient.
+- **Cohen's $\kappa$** when there are **exactly two** fixed raters, **complete** data, and **nominal** (or weighted) categories.
+- **Fleiss' $\kappa$** when every item has the **same** number of raters and the matrix is **complete**.
+- **Krippendorff's $\alpha$** when you have **missing** judgments, **variable** numbers of raters per unit, or you need **ordinal/interval/ratio** distances in one framework.
 
 ### 9.2 Decision flowchart (ASCII)
 
@@ -444,51 +485,42 @@ Together, the experiments support the thesis: **raw agreement misleads** under i
 
 ### 9.3 Thresholds (with caveats)
 
-No universal magic cutoff replaces domain judgment. Rules of thumb in the literature (e.g. Landis and Koch) were not built for modern skewed NLP corpora. Treat any **single** threshold as **heuristic**: use confidence intervals, **sensitivity** to prevalence, and **error analysis** on disagreed items. If \(\alpha \ll 0\) while \(A_o\) is high, prioritise **prevalence and chance** explanations before celebrating reliability.
+No universal magic cutoff replaces domain judgment. Rules of thumb in the literature (e.g. Landis and Koch) were not built for modern skewed NLP corpora. Treat any **single** threshold as **heuristic**: use confidence intervals, **sensitivity** to prevalence, and **error analysis** on disagreed items. If $\alpha \ll 0$ while $A_o$ is high, prioritise **prevalence and chance** explanations before celebrating reliability.
 
 ### 9.4 Reporting checklist
 
 When writing the methods section of a paper or an internal model card:
 
 1. State **which** agreement definition you use (within-item pairs vs global pool).
-2. Report **\(A_o\)** (or equivalent) **and** at least one **chance-aware** coefficient appropriate to your design.
-3. Disclose **\(K\)**, **approximate class frequencies**, and **missingness** rates.
-4. For \(\alpha\), name the **measurement level** (nominal vs ordinal, …) and the **value domain**.
+2. Report **$A_o$** (or equivalent) **and** at least one **chance-aware** coefficient appropriate to your design.
+3. Disclose **$K$**, **approximate class frequencies**, and **missingness** rates.
+4. For $\alpha$, name the **measurement level** (nominal vs ordinal, …) and the **value domain**.
 5. Archive **code and seeds** so figures and tables recompute.
 
 ### 9.5 What agreement coefficients cannot fix
 
-\(\alpha\) is not a substitute for **clear coding rules**, **training**, or **pilot studies**. If two groups of annotators apply different mental models of the task, you may still see **depressed** \(\alpha\) with confusion concentrated on a handful of ambiguous items — the right response is often **iterative guideline revision**, not more data. Coefficients also do not detect **biased** agreement: everyone could agree on the wrong answer (low validity, potentially high reliability). Finally, **non-independent** raters — discussing labels in a chat, copying neighbours, or sharing model outputs — violate the independence assumptions baked into chance models. The fix is **protocol design** (isolation, rotation, blinded conditions), not post-hoc algebra.
+$\alpha$ is not a substitute for **clear coding rules**, **training**, or **pilot studies**. If two groups of annotators apply different mental models of the task, you may still see **depressed** $\alpha$ with confusion concentrated on a handful of ambiguous items — the right response is often **iterative guideline revision**, not more data. Coefficients also do not detect **biased** agreement: everyone could agree on the wrong answer (low validity, potentially high reliability). Finally, **non-independent** raters — discussing labels in a chat, copying neighbours, or sharing model outputs — violate the independence assumptions baked into chance models. The fix is **protocol design** (isolation, rotation, blinded conditions), not post-hoc algebra.
 
 ---
 
 ## 10. Conclusion
 
-We opened with a deliberately uncomfortable claim: **high agreement is easy to manufacture**. Independent raters with skewed marginals agree often; raw \(A_o\) encodes that fact without labelling it as chance. Cohen's and Fleiss' \(\kappa\) subtract a **prevalence-aware** baseline and improve interpretation, yet they buckle under **imbalance paradoxes**, **missing data**, and **inflexible** nominal scaffolding.
+We opened with a deliberately uncomfortable claim: **high agreement is easy to manufacture**. Independent raters with skewed marginals agree often; raw $A_o$ encodes that fact without labelling it as chance. Cohen's and Fleiss' $\kappa$ subtract a **prevalence-aware** baseline and improve interpretation, yet they buckle under **imbalance paradoxes**, **missing data**, and **inflexible** nominal scaffolding.
 
-Krippendorff's \(\alpha\) reframes the question around **disagreement** weighted by meaningful distances, with a coincidence construction that absorbs **partial** observation patterns. The four experiments show, in controlled settings, that \(\alpha\) **behaves** as theory demands when annotators are random, **flags** the high-\(A_o\) trap, responds to **panel composition**, and **survives** missingness where Fleiss cannot.
+Krippendorff's $\alpha$ reframes the question around **disagreement** weighted by meaningful distances, with a coincidence construction that absorbs **partial** observation patterns. The four experiments show, in controlled settings, that $\alpha$ **behaves** as theory demands when annotators are random, **flags** the high-$A_o$ trap, responds to **panel composition**, and **survives** missingness where Fleiss cannot.
 
 For **ML practice**, the actionable message is procedural: **never** ship a single agreement percentage without stating the **chance benchmark**; **prefer** coefficients that match your **sampling** and **scale**; and **invest** in disagreement audits — especially when an LLM's agreement with humans is used as a proxy for safety or quality. Reliability is not the absence of large numbers; it is the **distance** between what you observe and what **random pairing** would produce.
 
-The opening hook — eighty percent is misleading — is not cynicism about human annotation. It is a reminder that **good faith** and **high overlap** are different random variables. The coefficients here, especially \(\alpha\), are tools for keeping that distinction visible when stakes are high.
-
----
-
-## Review note (Phase 5)
-
-Notation has been aligned across sections: \(A_o\) for pairwise observed agreement, \(A_e\) for independence baselines, \(\kappa\) for Kappa-family corrections, and \(\alpha\) for Krippendorff. Figures **1–6** are referenced in order: convergence (§3), Kappa paradox (§5), Experiments A–D (§8). Before publication, re-run all figure scripts after any change to `src.metrics` or `src.simulate`. For this repository’s MkDocs site, run `mkdocs build --strict`. For a portfolio export bundle, run `scripts/export_article_for_portfolio.py` and verify MathJax (or KaTeX) in your own HTML pipeline.
+The opening hook — eighty percent is misleading — is not cynicism about human annotation. It is a reminder that **good faith** and **high overlap** are different random variables. The coefficients here, especially $\alpha$, are tools for keeping that distinction visible when stakes are high.
 
 ---
 
 ## References
 
-1. Cohen, J. (1960). A coefficient of agreement for nominal scales. *Educational and Psychological Measurement*, 20(1), 37–46.
-2. Fleiss, J. L. (1971). Measuring nominal scale agreement among many raters. *Psychological Bulletin*, 76(5), 378–382.
-3. Feinstein, A. R., & Cicchetti, D. V. (1990). High agreement but low kappa: I. The problems of two paradoxes. *Journal of Clinical Epidemiology*, 43(6), 543–549.
-4. Krippendorff, K. (2004). *Content Analysis: An Introduction to Its Methodology* (2nd ed.). Sage. Chapter 11.
-5. Artstein, R., & Poesio, M. (2008). Inter-coder agreement for computational linguistics. *Computational Linguistics*, 34(4), 555–596.
-6. Landis, J. R., & Koch, G. G. (1977). The measurement of observer agreement for categorical data. *Biometrics*, 33(1), 159–174.
-
----
-
-*Draft article — Phase 5. Canonical source: `article/krippendorff-alpha.md`; figures from `figures/` via `scripts/` (see `article/README.md` and the repository README).*
+1. Cohen, J. (1960). A coefficient of agreement for nominal scales. *Educational and Psychological Measurement*, 20(1), 37–46. [doi:10.1177/001316446002000104](https://doi.org/10.1177/001316446002000104)
+2. Fleiss, J. L. (1971). Measuring nominal scale agreement among many raters. *Psychological Bulletin*, 76(5), 378–382. [doi:10.1037/h0031619](https://doi.org/10.1037/h0031619)
+3. Feinstein, A. R., & Cicchetti, D. V. (1990). High agreement but low kappa: I. The problems of two paradoxes. *Journal of Clinical Epidemiology*, 43(6), 543–549. [doi:10.1016/0895-4356(90)90158-L](https://doi.org/10.1016/0895-4356(90)90158-L)
+4. Krippendorff, K. (2004). *Content Analysis: An Introduction to Its Methodology* (2nd ed.). Sage. ISBN 978-0-7619-1544-7.
+5. Artstein, R., & Poesio, M. (2008). Inter-coder agreement for computational linguistics. *Computational Linguistics*, 34(4), 555–596. [doi:10.1162/coli.07-034-R2](https://doi.org/10.1162/coli.07-034-R2)
+6. Landis, J. R., & Koch, G. G. (1977). The measurement of observer agreement for categorical data. *Biometrics*, 33(1), 159–174. [doi:10.2307/2529310](https://doi.org/10.2307/2529310)
+7. Krippendorff, K. (2011). Computing Krippendorff’s Alpha-Reliability. *Departmental Papers (ASC)*, University of Pennsylvania. [Available online](https://repository.upenn.edu/asc_papers/43/)

--- a/article/krippendorff-alpha.pt-BR.md
+++ b/article/krippendorff-alpha.pt-BR.md
@@ -28,10 +28,6 @@ article_format:
 
 > **Tese.** Um índice de acordo de 0,80 entre anotadores é com mais frequência evidência de ruído estruturado e prevalência do que de consenso verdadeiro quando o acordo por acaso não é contabilizado. Métricas como acordo bruto tratam sobreposição como sinal; o alpha de Krippendorff modela **desacordo** face a um referencial de aleatoriedade e generaliza-se a vários anotadores, dados faltantes e escalas de medição.
 
-**Figuras.** Caminhos `../figures/<nome>.png` relativos a este ficheiro. Para exportar com `figures/` ao lado do Markdown, use `scripts/export_article_for_portfolio.py` (hoje exporta o `.md` em inglês por defeito; pode copiar este ficheiro manualmente ou estender o script).
-
-**Anotações.** Use comentários HTML `<!-- ... -->` ou um ramo à parte para marcar ajustes desejados.
-
 ---
 
 ## 1. Introdução
@@ -42,17 +38,17 @@ O **acordo observado** responde a uma pergunta estreita: que fração de **pares
 
 Isso pesa em **avaliação de LLMs**. Imagine um fluxo em que humanos e um modelo fine-tuned classificam projetos por marca. Negócio e jurídico querem um único número: “Concordamos?” Se só reportar a proporção de pares (humano, LLM) em acordo, um modelo que copia a classe majoritária pode parecer excelente sem julgamento cuidadoso. O mesmo armadilha aparece em codificação clínica, moderação de conteúdo e qualquer domínio com etiquetas enviesadas.
 
-A linguística computacional usa coeficientes de acordo há décadas (Artstein e Poesio, 2008). A maturidade em torno de \(\kappa\) é desigual: leaderboards ainda misturam métricas **estilo acurácia** com tarefas **carregadas de prevalência**. Com **modelos foundation** como anotadores por defeito, a pergunta deixa de ser “batemos 80%?” e passa a ser se a automação **acompanha** a permutabilidade humana sob as mesmas instruções — o que empurra para coeficientes que toleram observação **parcial** e respeitam a **escala**.
+A linguística computacional usa coeficientes de acordo há décadas (Artstein e Poesio, 2008). A maturidade em torno de $\kappa$ é desigual: leaderboards ainda misturam métricas **estilo acurácia** com tarefas **carregadas de prevalência**. Com **modelos foundation** como anotadores por defeito, a pergunta deixa de ser “batemos 80%?” e passa a ser se a automação **acompanha** a permutabilidade humana sob as mesmas instruções — o que empurra para coeficientes que toleram observação **parcial** e respeitam a **escala**.
 
 Este artigo segue um arco:
 
 1. Formalizar o acordo como **estimador** e separar **sinal** de **acaso** (Secções 2–3).
-2. Apresentar \(\kappa\) de **Cohen** e **Fleiss** como correção padrão, e onde **falham** (4–5).
+2. Apresentar $\kappa$ de **Cohen** e **Fleiss** como correção padrão, e onde **falham** (4–5).
 3. Reformular confiabilidade via **desacordo** e **matriz de coincidências**, até ao **alpha** de Krippendorff (6–7).
 4. **Validar** com quatro simulações controladas (8).
 5. Fechar com **guia prático** e limites honestos (9–10).
 
-**Notação:** \(K\) categorias, \(n\) itens, \(m\) anotadores salvo indicação contrária. Matriz \((X_{ij})\), \(X_{ij}\in\{1,\ldots,K\}\) (o código pode usar \(0,\ldots,K-1\)). Julgamentos faltantes quando indicado.
+**Notação:** $K$ categorias, $n$ itens, $m$ anotadores salvo indicação contrária. Matriz $(X_{ij})$, $X_{ij}\in\{1,\ldots,K\}$ (o código pode usar $0,\ldots,K-1$). Julgamentos faltantes quando indicado.
 
 ---
 
@@ -60,42 +56,42 @@ Este artigo segue um arco:
 
 ### 2.1 O problema da anotação
 
-Temos um **estudo de confiabilidade**: vários anotadores atribuem uma de \(K\) categorias **nominais** a cada um de \(n\) itens. Sem padrão-ouro; o objetivo é quantificar com que consistência os anotadores **reproduzem** os mesmos juízos sobre o mesmo conteúdo — **confiabilidade** (replicabilidade do processo), não **validade** (se as categorias correspondem ao mundo).
+Temos um **estudo de confiabilidade**: vários anotadores atribuem uma de $K$ categorias **nominais** a cada um de $n$ itens. Sem padrão-ouro; o objetivo é quantificar com que consistência os anotadores **reproduzem** os mesmos juízos sobre o mesmo conteúdo — **confiabilidade** (replicabilidade do processo), não **validade** (se as categorias correspondem ao mundo).
 
 Pode haver alta confiabilidade e baixa validade (todos aplicam o mesmo guia errado) e o inverso. Este texto trata **só** da primeira questão: se o **procedimento** de anotação é estável entre pessoas e, por extensão, se um sistema automatizado que as imita está alinhado num sentido **replicável**.
 
 ### 2.2 Acordo observado por pares
 
-Fixe um item \(i\). Seja \(S_i\) o conjunto de pares não ordenados \((j,\ell)\), \(j<\ell\), em que **ambos** \(X_{ij}\) e \(X_{i\ell}\) estão observados. Indicador \(I_{ij\ell}=1\) se \(X_{ij}=X_{i\ell}\), senão \(0\).
+Fixe um item $i$. Seja $S_i$ o conjunto de pares não ordenados $(j,\ell)$, $j<\ell$, em que **ambos** $X_{ij}$ e $X_{i\ell}$ estão observados. Indicador $I_{ij\ell}=1$ se $X_{ij}=X_{i\ell}$, senão $0$.
 
 O **acordo observado** é a fração de pares comparáveis em acordo:
 
-\[
+$$
 A_o
 =
 \frac{\displaystyle\sum_{i=1}^n \sum_{(j,\ell)\in S_i} I_{ij\ell}}
      {\displaystyle\sum_{i=1}^n |S_i|}.
-\]
+$$
 
-Assim \(A_o\) é uma **proporção amostral** de pares concordantes, agregada pelos itens.
+Assim $A_o$ é uma **proporção amostral** de pares concordantes, agregada pelos itens.
 
-**Exemplo (3 itens, 2 anotadores).** Itens 1 e 3 concordam; o 2 discorda. Então \(A_o=2/3\).
+**Exemplo (3 itens, 2 anotadores).** Itens 1 e 3 concordam; o 2 discorda. Então $A_o=2/3$.
 
 ### 2.3 Acordo global com reposição
 
-Alguns relatórios usam um resumo **global**: agregam todos os julgamentos, \(N\) o tamanho do pool, \(n_k\) a contagem da categoria \(k\), e imaginam **dois sorteios uniformes com reposição** do pool. A probabilidade de ambos serem \(k\) é \((n_k/N)^2\), logo
+Alguns relatórios usam um resumo **global**: agregam todos os julgamentos, $N$ o tamanho do pool, $n_k$ a contagem da categoria $k$, e imaginam **dois sorteios uniformes com reposição** do pool. A probabilidade de ambos serem $k$ é $(n_k/N)^2$, logo
 
-\[
+$$
 P(\text{acordo}) = \sum_{k=1}^K \Bigl(\frac{n_k}{N}\Bigr)^2.
-\]
+$$
 
-Coincide com o \(A_o\) por pares dentro do item em desenhos simples e balanceados, mas **diverge** com \(m\) variável ou faltantes desiguais. O código do repositório implementa ambas as variantes.
+Coincide com o $A_o$ por pares dentro do item em desenhos simples e balanceados, mas **diverge** com $m$ variável ou faltantes desiguais. O código do repositório implementa ambas as variantes.
 
-### 2.4 O que \(A_o\) estima — e o que não estima
+### 2.4 O que $A_o$ estima — e o que não estima
 
-\(A_o\) é uma estatística **descritiva** clara. **Não** mede “quanto melhor que o acaso” age o painel. Dois anotadores independentes com distribuição \(\pi\) concordam com probabilidade \(\sum_k\pi_k^2\), muitas vezes bem acima de zero. Se o seu \(A_o\) reportado está perto disso, os dados são compatíveis com **independência**, não com verdade latente partilhada.
+$A_o$ é uma estatística **descritiva** clara. **Não** mede “quanto melhor que o acaso” age o painel. Dois anotadores independentes com distribuição $\pi$ concordam com probabilidade $\sum_k\pi_k^2$, muitas vezes bem acima de zero. Se o seu $A_o$ reportado está perto disso, os dados são compatíveis com **independência**, não com verdade latente partilhada.
 
-Como qualquer proporção, \(A_o\) tem **variabilidade amostral**; nos experimentos usa-se \(n=10{,}000\) em parte para curvas estáveis. Na prática, use intervalos de confiança e vistas desagregadas.
+Como qualquer proporção, $A_o$ tem **variabilidade amostral**; nos experimentos usa-se $n=10{,}000$ em parte para curvas estáveis. Na prática, use intervalos de confiança e vistas desagregadas.
 
 ---
 
@@ -103,43 +99,43 @@ Como qualquer proporção, \(A_o\) tem **variabilidade amostral**; nos experimen
 
 ### 3.1 Acordo esperado sob independência
 
-**Modelo.** Dois anotadores etiquetam **independentemente**, cada um com a mesma distribuição \(\pi=(\pi_1,\ldots,\pi_K)\). Então
+**Modelo.** Dois anotadores etiquetam **independentemente**, cada um com a mesma distribuição $\pi=(\pi_1,\ldots,\pi_K)$. Então
 
-\[
+$$
 A_e
 =
 P(\text{ambos na mesma categoria})
 =
 \sum_{k=1}^K \pi_k^2.
-\]
+$$
 
-Se \(\pi_k=1/K\), \(A_e=1/K\). Para \(K=2\), “moedas” independentes concordam metade do tempo **sem** verdade partilhada.
+Se $\pi_k=1/K$, $A_e=1/K$. Para $K=2$, “moedas” independentes concordam metade do tempo **sem** verdade partilhada.
 
-**Exemplo desbalanceado.** \(\pi=(0{,}7,0{,}2,0{,}1)\):
+**Exemplo desbalanceado.** $\pi=(0{,}7,0{,}2,0{,}1)$:
 
-\[
+$$
 A_e = 0{,}7^2+0{,}2^2+0{,}1^2 = 0{,}54.
-\]
+$$
 
-| Cenário | \(A_e=\sum_k\pi_k^2\) |
+| Cenário | $A_e=\sum_k\pi_k^2$ |
 |---------|------------------------|
-| \(K=2\), uniforme | \(0{,}50\) |
-| \(K=3\), uniforme | \(\approx 0{,}333\) |
-| \(K=3\), \(\pi=(0{,}7,0{,}2,0{,}1)\) | \(0{,}54\) |
+| $K=2$, uniforme | $0{,}50$ |
+| $K=3$, uniforme | $\approx 0{,}333$ |
+| $K=3$, $\pi=(0{,}7,0{,}2,0{,}1)$ | $0{,}54$ |
 
-### 3.2 Anotadores aleatórios: por que \(A_o\not\to 0\)
+### 3.2 Anotadores aleatórios: por que $A_o\not\to 0$
 
-Se cada célula da matriz é **independente** \(\sim\pi\) (sem verdade latente por item), dois julgamentos no mesmo item concordam com probabilidade **exatamente** \(\sum_k\pi_k^2>0\).
+Se cada célula da matriz é **independente** $\sim\pi$ (sem verdade latente por item), dois julgamentos no mesmo item concordam com probabilidade **exatamente** $\sum_k\pi_k^2>0$.
 
 **“Aleatório” não é “acordo zero”**; é acordo ao nível de **acaso** das marginais.
 
 ### 3.3 Verificação empírica
 
-A Fase 1 do código simula anotadores i.i.d. puramente aleatórios; o \(A_o\) empírico concentra-se em \(\sum_k\pi_k^2\).
+A Fase 1 do código simula anotadores i.i.d. puramente aleatórios; o $A_o$ empírico concentra-se em $\sum_k\pi_k^2$.
 
 ![Convergência simulada do acordo observado ao referencial de independência.](../figures/random_agreement_convergence.png)
 
-**Figura 1.** \(A_o\) empírico aproxima \(A_e=\sum_k\pi_k^2\) quando \(n\) cresce.
+**Figura 1.** $A_o$ empírico aproxima $A_e=\sum_k\pi_k^2$ quando $n$ cresce.
 
 ---
 
@@ -147,33 +143,33 @@ A Fase 1 do código simula anotadores i.i.d. puramente aleatórios; o \(A_o\) em
 
 ### 4.1 Padrão de correção
 
-\[
+$$
 \kappa = \frac{A_o-A_e}{1-A_e}.
-\]
+$$
 
-Se \(A_e<1\): \(\kappa=1\) se \(A_o=1\); \(\kappa=0\) se \(A_o=A_e\); \(\kappa<0\) se abaixo do referencial.
+Se $A_e<1$: $\kappa=1$ se $A_o=1$; $\kappa=0$ se $A_o=A_e$; $\kappa<0$ se abaixo do referencial.
 
 ### 4.2 Kappa de Cohen (dois anotadores fixos)
 
-\[
+$$
 A_o = \frac{1}{n}\sum_{i=1}^n \mathbf{1}\{X_{i1}=X_{i2}\}.
-\]
+$$
 
-Com marginais empíricas \(p_{k\cdot}\), \(p_{\cdot k}\):
+Com marginais empíricas $p_{k\cdot}$, $p_{\cdot k}$:
 
-\[
+$$
 A_e = \sum_{k=1}^K p_{k\cdot}\,p_{\cdot k},
 \qquad
 \kappa_C=\frac{A_o-A_e}{1-A_e}.
-\]
+$$
 
 ### 4.3 Kappa de Fleiss
 
-\(P_i = \frac{1}{m(m-1)}\sum_k n_{ik}(n_{ik}-1)\), \(\bar P=\frac1n\sum_i P_i\), \(p_k=\frac{1}{nm}\sum_i n_{ik}\), \(\bar P_e=\sum_k p_k^2\), \(\kappa_F=(\bar P-\bar P_e)/(1-\bar P_e)\).
+$P_i = \frac{1}{m(m-1)}\sum_k n_{ik}(n_{ik}-1)$, $\bar P=\frac1n\sum_i P_i$, $p_k=\frac{1}{nm}\sum_i n_{ik}$, $\bar P_e=\sum_k p_k^2$, $\kappa_F=(\bar P-\bar P_e)/(1-\bar P_e)$.
 
 ### 4.4 Por que Kappa ajuda
 
-Reexprime sobreposição face a um referencial de acaso **estimado dos dados**. Quando \(A_o\) é alto só porque \(\bar P_e\) é alto, \(\kappa_F\) aproxima-se de zero.
+Reexprime sobreposição face a um referencial de acaso **estimado dos dados**. Quando $A_o$ é alto só porque $\bar P_e$ é alto, $\kappa_F$ aproxima-se de zero.
 
 ---
 
@@ -181,17 +177,17 @@ Reexprime sobreposição face a um referencial de acaso **estimado dos dados**. 
 
 ### 5.1 Paradoxo do Kappa
 
-Prevalência extrema infla \(\sum_k p_k^2\); \(A_o\) bruto pode ser alto com \(\kappa\) baixo — o coeficiente está a fazer o trabalho dele.
+Prevalência extrema infla $\sum_k p_k^2$; $A_o$ bruto pode ser alto com $\kappa$ baixo — o coeficiente está a fazer o trabalho dele.
 
 ![Kappa de Fleiss vs desbalanceamento (paradoxo).](../figures/kappa_paradox.png)
 
-**Figura 2.** \(\kappa_F\) pode cair com \(A_o\) ainda “alto” em escalas ingénuas.
+**Figura 2.** $\kappa_F$ pode cair com $A_o$ ainda “alto” em escalas ingénuas.
 
 ### 5.2 Restrições estruturais
 
 Cohen: exatamente **dois** anotadores; Fleiss: grelha **completa** tipicamente; ambos **nominais** na forma básica.
 
-### 5.3 Por que \(\alpha\)
+### 5.3 Por que $\alpha$
 
 Precisamos de desacordo comparável ao acaso, **dados faltantes** e **distâncias** entre valores — o alpha de Krippendorff cobre isso num único esqueleto.
 
@@ -199,63 +195,138 @@ Precisamos de desacordo comparável ao acaso, **dados faltantes** e **distância
 
 ## 6. Do acordo ao desacordo
 
-Contagens de **acertos** vs **distâncias** entre etiquetas. Matriz de confiabilidade (unidades \(\times\) anotadores); **matriz de coincidências** \(\mathbf{O}\); esperada \(\mathbf{E}\) sob reemparelhamento aleatório que preserva marginais; **discrepância** ponderada por \(\mathbf{D}\).
+### 6.1 Por que mudar a perspetiva
+
+Acordo bruto e os numeradores do Kappa contam **acertos**: quantos pares deram a mesma etiqueta? A visão dual conta **desacertos** ponderados pela distância entre as categorias atribuídas. Para dados nominais, a distância é binária — igual ou diferente. Para dados de intervalo, diferenças ao quadrado penalizam erros grandes mais que erros pequenos. Essa visão dual é mais geral: acomoda naturalmente **escalas de medição** além da nominal e conduz a uma fórmula única que unifica todos os casos.
+
+### 6.2 A matriz de confiabilidade
+
+A construção de Krippendorff parte de uma **matriz de confiabilidade**: linhas são **unidades** (itens), colunas são **anotadores**, entradas são valores (categorias ou pontuações numéricas). Entradas faltantes são **excluídas** de todos os cálculos; só pares de anotadores distintos na mesma unidade contribuem informação. Uma unidade com uma única etiqueta observada não forma par e é silenciosamente descartada — sem imputação, sem eliminação de linhas.
+
+### 6.3 Construção da matriz de coincidências — exemplo trabalhado
+
+Considere três itens avaliados por três anotadores num domínio binário $\{A, B\}$:
+
+| Unidade | Anotador 1 | Anotador 2 | Anotador 3 |
+|---------|------------|------------|------------|
+| 1       | A          | A          | B          |
+| 2       | B          | B          | —          |
+| 3       | A          | A          | A          |
+
+**Passo 1 — vetores de contagem.** Para cada unidade, contar quantas vezes cada valor aparece entre as avaliações **observadas**:
+
+- Unidade 1: $\mathbf{n}_1 = (2, 1)$, com $m_1 = 3$ anotadores.
+- Unidade 2: $\mathbf{n}_2 = (0, 2)$, com $m_2 = 2$ anotadores (Anotador 3 faltante).
+- Unidade 3: $\mathbf{n}_3 = (3, 0)$, com $m_3 = 3$ anotadores.
+
+**Passo 2 — contribuições locais de coincidência.** Para cada unidade, a contribuição à matriz de coincidências é proporcional à frequência com que pares de anotadores **distintos** atribuíram cada combinação de valores. Para uma unidade com vetor de contagem $\mathbf{n}_i$, a entrada fora da diagonal $(c, c')$ recebe $n_{ic} \cdot n_{ic'}/(m_i - 1)$, e a entrada diagonal $(c, c)$ recebe $n_{ic}(n_{ic} - 1)/(m_i - 1)$. O denominador $m_i - 1$ garante que cada unidade contribui **uma unidade de massa total** independentemente do número de anotadores.
+
+Aplicando ao exemplo:
+
+- **Unidade 1** ($m_1 = 3$): diagonal $(A,A) = 2 \cdot 1 / 2 = 1$; diagonal $(B,B) = 1 \cdot 0 / 2 = 0$; fora da diagonal $(A,B) = 2 \cdot 1 / 2 = 1$.
+- **Unidade 2** ($m_2 = 2$): diagonal $(B,B) = 2 \cdot 1 / 1 = 2$; restante zero.
+- **Unidade 3** ($m_3 = 3$): diagonal $(A,A) = 3 \cdot 2 / 2 = 3$; restante zero.
+
+**Passo 3 — somar para obter $\mathbf{O}$.**
+
+|       | A   | B   |
+|-------|-----|-----|
+| **A** | 4   | 1   |
+| **B** | 1   | 2   |
+
+As marginais são $n_A = 5$, $n_B = 3$, e a massa total emparelhável é $N = 8$.
+
+**Passo 4 — coincidência esperada $\mathbf{E}$.** Sob a hipótese nula de reemparelhamento aleatório preservando marginais, $E_{cc'} = (n_c n_{c'} - n_c \delta_{cc'}) / (N - 1)$. Por exemplo, $E_{AB} = (5 \cdot 3) / 7 \approx 2{,}14$ e $E_{AA} = (5 \cdot 4) / 7 \approx 2{,}86$.
+
+### 6.4 De coincidência a desacordo
+
+O **desacordo observado** é a soma ponderada $D_o^* = \sum_{c,c'} O_{cc'} D_{cc'}$, onde $D_{cc'} = \delta(c, c')$ codifica a distância. O **desacordo esperado** $D_e^*$ usa $\mathbf{E}$ na mesma fórmula. A razão $D_o^* / D_e^*$ indica como o padrão real de desacordos do painel se compara ao que o emparelhamento aleatório produziria.
+
+A mudança conceitual é simples: em vez de "com que frequência concordamos?", perguntar **"quão mais longe estamos do que o emparelhamento aleatório preveria?"** Acordo é o caso especial em que a distância é zero na diagonal e um fora dela ($\delta$ nominal). A Secção 7 monta essas peças na fórmula completa de $\alpha$.
 
 ---
 
 ## 7. Alpha de Krippendorff
 
-\[
+$$
 D_o^\* = \sum_{c,c'} O_{cc'}D_{cc'},
 \quad
 D_e^\* = \sum_{c,c'} E_{cc'}D_{cc'},
 \quad
 \alpha = 1-\frac{D_o^\*}{D_e^\*}.
-\]
+$$
 
-\[
+$$
 E_{cc'} = \frac{n_c n_{c'}-n_c\delta_{cc'}}{N-1}.
-\]
+$$
 
-**Limites:** \(\alpha=1\) se \(D_o^\*=0\) (caso nominal perfeito); \(\alpha=0\) se \(D_o^\*=D_e^\*\); \(\alpha<0\) se \(D_o^\*>D_e^\*\).
+**Limites:** $\alpha=1$ se $D_o^\*=0$ (caso nominal perfeito); $\alpha=0$ se $D_o^\*=D_e^\*$; $\alpha<0$ se $D_o^\*>D_e^\*$.
 
-\[
+$$
 \alpha = \frac{D_e^\*-D_o^\*}{D_e^\*}.
-\]
+$$
 
-Relação com Cohen: modelos de acaso diferentes se \(K>2\) — não espere igualdade numérica.
+Relação com Cohen: modelos de acaso diferentes se $K>2$ — não espere igualdade numérica.
 
-**Distâncias \(\delta\):** nominal — \(0\) se \(c=c'\), senão \(1\); intervalo — \((c-c')^2\); ratio — \(\bigl(\frac{c-c'}{c+c'}\bigr)^2\) (convenção se \(c+c'=0\)); ordinal — usa domínio ordenado e massas \(n_v\) (Krippendorff 2004, cap. 11).
+**Distâncias $\delta$:** nominal — $0$ se $c=c'$, senão $1$; intervalo — $(c-c')^2$; ratio — $\bigl(\frac{c-c'}{c+c'}\bigr)^2$ (convenção se $c+c'=0$); ordinal — usa domínio ordenado e massas $n_v$ (Krippendorff 2004, cap. 11).
 
 ---
 
 ## 8. Experimentos
 
-Quatro simulações com **sementes fixas** (`make experiments` ou `scripts/experiment_*.py`).
+Quatro simulações (Fase 4 do código) isolam propriedades de $A_o$, $\kappa_F$ e $\alpha$. Todas usam **sementes fixas** e são reproduzíveis via `make experiments` ou os scripts individuais `scripts/experiment_*.py`.
+
+São **sintéticas** de propósito: alvos analíticos existem para etiquetagem aleatória, e varrimentos sobre ruído e desbalanceamento são baratos de repetir. Traduzir as lições qualitativas para uma API de LLM real requer camadas adicionais (calibração, prompts adversariais, fatores humanos) que ficam fora deste texto — mas as **armadilhas algébricas** do acordo bruto e os **limites estruturais** de Fleiss permanecem.
 
 ### 8.1 A — Anotadores aleatórios
 
-\(A_o\approx 1/K\); \(\kappa_F,\alpha\approx 0\).
+**Setup.** Etiquetagem i.i.d. pura, categorias uniformes. Varrimento de $K \in \{2,\ldots,10\}$ com $n=10{,}000$, $m=5$.
 
-![Experimento A.](../figures/exp_a_random_metrics.png)
+**Expectativa.** $A_o \approx 1/K$; $\kappa_F \approx 0$; $\alpha \approx 0$.
+
+**Resultado.** As curvas empíricas correspondem à teoria dentro de tolerância apertada. Este é o **teste de sanidade**: coeficientes corrigidos pelo acaso anulam-se quando não há estrutura partilhada além da independência. Se só reportar $A_o$ e variar o número de categorias entre estudos, a escala **bruta** move-se com $1/K$ mesmo quando o comportamento é “maximamente não informativo”.
+
+![Experimento A: $A_o$, $\kappa_F$ e $\alpha$ para anotadores aleatórios i.i.d. ao longo de $K$.](../figures/exp_a_random_metrics.png)
+
+**Figura 3.** Anotadores aleatórios: acordo observado segue $1/K$; $\kappa_F$ e $\alpha$ seguem zero.
 
 ### 8.2 B — Armadilha do alto acordo
 
-\(A_o\) alto com \(\alpha\) baixo sob skew + baixo ruído.
+**Setup.** Forte enviesamento de classe e baixo ruído de anotação num painel de cinco anotadores. Grelha sobre desbalanceamento e $\varepsilon$.
 
-![Experimento B.](../figures/exp_b_agreement_trap_heatmap.png)
+**Expectativa.** Regiões onde $A_o$ **bruto** permanece alto mas $\alpha$ (e $\kappa_F$) caem — a **armadilha** central da tese.
+
+**Resultado.** Heatmaps de $A_o$ e $\alpha$ mostram uma cunha visível onde $A_o > 0{,}8$ enquanto $\alpha < 0{,}4$. Este é o **padrão central** do artigo: stakeholders veem uma percentagem **confortável** enquanto os coeficientes corrigidos pelo acaso indicam que o painel é apenas modestamente melhor que um referencial aleatório consciente da prevalência.
+
+![Experimento B: heatmaps de $\alpha$ e $A_o$ sobre desbalanceamento e ruído.](../figures/exp_b_agreement_trap_heatmap.png)
+
+**Figura 4.** Armadilha do acordo: sobreposição bruta alta coexiste com confiabilidade corrigida baixa sob enviesamento + baixo ruído.
 
 ### 8.3 C — LLM vs humanos (sintético)
 
-Sensibilidade ao ruído do “LLM”.
+**Setup.** Três anotadores “humanos” com ruído $\varepsilon = 0{,}10$ e um anotador “LLM” com $\varepsilon = 0{,}15$ numa tarefa de três classes; sensibilidade sobre ruído do LLM em $[0, 0{,}5]$.
 
-![Experimento C.](../figures/exp_c_llm_vs_humans.png)
+**Resultado.** $\alpha$ e métricas relacionadas **acompanham** a qualidade do painel; adicionar um anotador mais ruidoso tende a **reduzir** $\alpha$ do painel relativamente ao sub-painel só de humanos. A curva de sensibilidade torna a relação dose-resposta visível para o parâmetro de ruído sintético (substituto para qualidade do modelo, não uma afirmação sobre uma API específica).
+
+![Experimento C: sensibilidade de $\alpha$ ao ruído sintético do LLM.](../figures/exp_c_llm_vs_humans.png)
+
+**Figura 5.** LLM sintético vs humanos: $\alpha$ responde ao ruído injetado do LLM; comparar só humanos com o painel completo.
 
 ### 8.4 D — Dados faltantes
 
-\(\alpha\) estável; Fleiss vira `NaN` com células faltantes.
+**Setup.** Painel balanceado fixo com ruído moderado; injetar faltantes MCAR de 0% a 50%.
 
-![Experimento D.](../figures/exp_d_missing_robustness.png)
+**Expectativa.** A formulação de Fleiss (matriz completa) torna-se **indefinida** ou `NaN` com entradas faltantes; $\alpha$ **degrada graciosamente** porque é definido sobre unidades emparelháveis.
+
+**Resultado.** $\alpha$ permanece estável perto do seu valor com dados completos enquanto Fleiss desaparece — uma razão prática para preferir $\alpha$ em regimes de anotação esparsa. Anotadores reais desistem a meio de lotes, pull requests dividem pools de revisores, e chamadas de LLM dão timeout. Uma métrica que requer **imputação** ou **eliminação de linhas** para retornar um número convida viés silencioso.
+
+![Experimento D: $\alpha$ vs $\kappa_F$ à medida que a taxa de faltantes aumenta.](../figures/exp_d_missing_robustness.png)
+
+**Figura 6.** Dados faltantes: $\alpha$ mantém-se informativo; Fleiss requer matriz completa.
+
+### 8.5 Síntese
+
+Em conjunto, os experimentos suportam a tese: **acordo bruto engana** sob independência e enviesamento; **Kappa** corrige parcialmente mas herda limites estruturais; **$\alpha$** lida com faltantes e unifica o pensamento baseado em desacordo — validado aqui sobre verdade sintética onde as expectativas são analíticas ou visualmente claras.
 
 ---
 
@@ -263,9 +334,9 @@ Sensibilidade ao ruído do “LLM”.
 
 ### 9.1 Quando usar cada métrica
 
-- Reporte \(A_o\) como resumo transparente sensível à prevalência, **sempre** com um coeficiente consciente do acaso.
+- Reporte $A_o$ como resumo transparente sensível à prevalência, **sempre** com um coeficiente consciente do acaso.
 - **Kappa de Cohen** com exatamente **dois** anotadores fixos, dados **completos**, categorias **nominais** (ou kappa ponderado).
-- **Kappa de Fleiss** quando cada item tem o **mesmo** \(m\) e a matriz está **completa**.
+- **Kappa de Fleiss** quando cada item tem o **mesmo** $m$ e a matriz está **completa**.
 - **Alpha de Krippendorff** com julgamentos **faltantes**, número **variável** de anotadores por unidade, ou distâncias **ordinal/intervalo/ratio** num só quadro.
 
 ### 9.2 Fluxograma (ASCII)
@@ -292,40 +363,40 @@ Sensibilidade ao ruído do “LLM”.
 
 ### 9.3 Limiares (com ressalvas)
 
-Não há corte universal que substitua julgamento de domínio. Regras tipo Landis–Koch não foram feitas para corpora NLP modernos enviesados. Trate qualquer limiar único como **heurística**: intervalos de confiança, sensibilidade à prevalência, análise de erros nos itens em desacordo. Se \(\alpha \ll 0\) com \(A_o\) alto, investigue **prevalência e acaso** antes de celebrar confiabilidade.
+Não há corte universal que substitua julgamento de domínio. Regras tipo Landis–Koch não foram feitas para corpora NLP modernos enviesados. Trate qualquer limiar único como **heurística**: intervalos de confiança, sensibilidade à prevalência, análise de erros nos itens em desacordo. Se $\alpha \ll 0$ com $A_o$ alto, investigue **prevalência e acaso** antes de celebrar confiabilidade.
 
 ### 9.4 Checklist de relatório
 
 1. Qual definição de acordo (pares dentro do item vs pool global).
-2. \(A_o\) (ou equivalente) **e** pelo menos um coeficiente consciente do acaso adequado ao desenho.
-3. Declarar \(K\), frequências de classe aproximadas, taxa de faltantes.
-4. Para \(\alpha\): nível de medição e **domínio de valores**.
+2. $A_o$ (ou equivalente) **e** pelo menos um coeficiente consciente do acaso adequado ao desenho.
+3. Declarar $K$, frequências de classe aproximadas, taxa de faltantes.
+4. Para $\alpha$: nível de medição e **domínio de valores**.
 5. Arquivar **código e sementes** para refazer figuras e tabelas.
 
 ### 9.5 O que coeficientes não consertam
 
-\(\alpha\) não substitui **regras de codificação**, **treino** ou **piloto**. Desacordo concentrado em poucos itens ambíguos pede **revisão do guia**, não só mais dados. Acordo enviesado (todos erram da mesma forma) não é detetado como problema de validade. **Anotadores não independentes** (chat, cópia, partilha de outputs de modelo) violam pressupostos; a solução é **protocolo**, não álgebra posterior.
+$\alpha$ não substitui **regras de codificação**, **treino** ou **piloto**. Desacordo concentrado em poucos itens ambíguos pede **revisão do guia**, não só mais dados. Acordo enviesado (todos erram da mesma forma) não é detetado como problema de validade. **Anotadores não independentes** (chat, cópia, partilha de outputs de modelo) violam pressupostos; a solução é **protocolo**, não álgebra posterior.
 
 ---
 
 ## 10. Conclusão
 
-Acordo alto é fácil de fabricar com marginais enviesadas. Kappa corrige parte do problema; alpha reformula via desacordo e lida melhor com incompletude. Para ML: nunca um único percentual sem referencial de acaso; prefira o coeficiente que corresponde ao desenho amostral e à escala.
+Abrimos com uma afirmação deliberadamente desconfortável: **acordo alto é fácil de fabricar**. Anotadores independentes com marginais enviesadas concordam frequentemente; $A_o$ bruto codifica esse facto sem o rotular como acaso. Os $\kappa$ de Cohen e Fleiss subtraem um referencial **consciente da prevalência** e melhoram a interpretação, mas cedem sob **paradoxos de desbalanceamento**, **dados faltantes** e scaffolding **nominal inflexível**.
 
----
+O $\alpha$ de Krippendorff reformula a questão em torno de **desacordo** ponderado por distâncias significativas, com uma construção de coincidência que absorve padrões de observação **parcial**. Os quatro experimentos mostram, em condições controladas, que $\alpha$ **comporta-se** como a teoria exige quando anotadores são aleatórios, **sinaliza** a armadilha do alto $A_o$, responde à **composição do painel**, e **sobrevive** a faltantes onde Fleiss não consegue.
 
-## Nota de revisão
+Para **prática de ML**, a mensagem operacional é procedimental: **nunca** enviar um único percentual de acordo sem declarar o **referencial de acaso**; **preferir** coeficientes que correspondam ao **desenho amostral** e à **escala**; e **investir** em auditorias de desacordo — especialmente quando o acordo de um LLM com humanos é usado como proxy para segurança ou qualidade. Confiabilidade não é a ausência de números grandes; é a **distância** entre o que se observa e o que o **emparelhamento aleatório** produziria.
 
-Figuras 1–6 na mesma ordem que a versão EN. Para o site MkDocs deste repositório: `mkdocs build` (o include `_article_include.md` usa só o `.md` em inglês). Para estudar derivações no papel, veja `docs/math-derivations-checklist.md`.
+O gancho inicial — oitenta por cento é enganador — não é cinismo sobre anotação humana. É um lembrete de que **boa fé** e **alta sobreposição** são variáveis aleatórias diferentes. Os coeficientes aqui apresentados, especialmente $\alpha$, são ferramentas para manter essa distinção visível quando os riscos são altos.
 
 ---
 
 ## Referências
 
-(As mesmas da versão em inglês.)
-
-1. Cohen (1960); 2. Fleiss (1971); 3. Feinstein & Cicchetti (1990); 4. Krippendorff (2004); 5. Artstein & Poesio (2008); 6. Landis & Koch (1977).
-
----
-
-*Rascunho de revisão PT-BR — alinhar com `article/krippendorff-alpha.md` antes da publicação final.*
+1. Cohen, J. (1960). A coefficient of agreement for nominal scales. *Educational and Psychological Measurement*, 20(1), 37–46. [doi:10.1177/001316446002000104](https://doi.org/10.1177/001316446002000104)
+2. Fleiss, J. L. (1971). Measuring nominal scale agreement among many raters. *Psychological Bulletin*, 76(5), 378–382. [doi:10.1037/h0031619](https://doi.org/10.1037/h0031619)
+3. Feinstein, A. R., & Cicchetti, D. V. (1990). High agreement but low kappa: I. The problems of two paradoxes. *Journal of Clinical Epidemiology*, 43(6), 543–549. [doi:10.1016/0895-4356(90)90158-L](https://doi.org/10.1016/0895-4356(90)90158-L)
+4. Krippendorff, K. (2004). *Content Analysis: An Introduction to Its Methodology* (2nd ed.). Sage. ISBN 978-0-7619-1544-7.
+5. Artstein, R., & Poesio, M. (2008). Inter-coder agreement for computational linguistics. *Computational Linguistics*, 34(4), 555–596. [doi:10.1162/coli.07-034-R2](https://doi.org/10.1162/coli.07-034-R2)
+6. Landis, J. R., & Koch, G. G. (1977). The measurement of observer agreement for categorical data. *Biometrics*, 33(1), 159–174. [doi:10.2307/2529310](https://doi.org/10.2307/2529310)
+7. Krippendorff, K. (2011). Computing Krippendorff's Alpha-Reliability. *Departmental Papers (ASC)*, University of Pennsylvania. [Available online](https://repository.upenn.edu/asc_papers/43/)

--- a/mkdocs_docs/javascripts/mathjax.js
+++ b/mkdocs_docs/javascripts/mathjax.js
@@ -1,7 +1,7 @@
 window.MathJax = {
   tex: {
-    inlineMath: [["\\(", "\\)"]],
-    displayMath: [["\\[", "\\]"]],
+    inlineMath: [["\\(", "\\)"], ["$", "$"]],
+    displayMath: [["\\[", "\\]"], ["$$", "$$"]],
     processEscapes: true,
     processEnvironments: true,
   },

--- a/scripts/export_article_for_portfolio.py
+++ b/scripts/export_article_for_portfolio.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Export `article/krippendorff-alpha.md` + figures for a portfolio repo (MD → HTML pipeline).
+"""Export article + figures for a portfolio repo (MD → HTML pipeline).
 
-The canonical article uses paths `../figures/*.png` (correct inside this monorepo).
+The canonical articles use paths `../figures/*.png` (correct inside this monorepo).
 This script writes a self-contained folder:
 
   <out>/
@@ -11,6 +11,7 @@ This script writes a self-contained folder:
 
 Usage:
   python scripts/export_article_for_portfolio.py
+  python scripts/export_article_for_portfolio.py --lang pt-BR
   python scripts/export_article_for_portfolio.py --out TARGET_DIR
 """
 
@@ -23,8 +24,21 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-ARTICLE = ROOT / "article" / "krippendorff-alpha.md"
+
+ARTICLES = {
+    "en": ROOT / "article" / "krippendorff-alpha.md",
+    "pt-BR": ROOT / "article" / "krippendorff-alpha.pt-BR.md",
+}
+
 FIG_REF = re.compile(r"\]\(\.\./figures/([^)]+)\)")
+
+
+def strip_yaml_frontmatter(text: str) -> str:
+    """Remove YAML frontmatter delimited by --- at the start of the file."""
+    if text.startswith("---"):
+        end = text.index("---", 3)
+        text = text[end + 3 :].lstrip("\n")
+    return text
 
 
 def main() -> None:
@@ -35,14 +49,23 @@ def main() -> None:
         default=ROOT / "dist" / "portfolio-article",
         help="Output directory (default: dist/portfolio-article)",
     )
+    parser.add_argument(
+        "--lang",
+        choices=["en", "pt-BR"],
+        default="en",
+        help="Article language to export (default: en)",
+    )
     args = parser.parse_args()
     out: Path = args.out.resolve()
+    article_path = ARTICLES[args.lang]
 
-    if not ARTICLE.is_file():
-        print(f"Missing {ARTICLE}", file=sys.stderr)
+    if not article_path.is_file():
+        print(f"Missing {article_path}", file=sys.stderr)
         sys.exit(1)
 
-    text = ARTICLE.read_text(encoding="utf-8")
+    text = article_path.read_text(encoding="utf-8")
+    text = strip_yaml_frontmatter(text)
+
     needed = sorted(set(FIG_REF.findall(text)))
     if not needed:
         print("No ../figures/ references found in article.", file=sys.stderr)
@@ -61,9 +84,10 @@ def main() -> None:
         shutil.copy2(src, fig_out / name)
 
     portable = text.replace("](../figures/", "](figures/")
-    (out / "krippendorff-alpha.md").write_text(portable, encoding="utf-8")
+    out_filename = article_path.name
+    (out / out_filename).write_text(portable, encoding="utf-8")
 
-    print(f"Wrote {out / 'krippendorff-alpha.md'}")
+    print(f"Wrote {out / out_filename}")
     print(f"Copied {len(needed) - len(missing)} PNG(s) to {fig_out}/")
     if missing:
         msg = "Missing source PNGs (run figure scripts first): " + ", ".join(missing)


### PR DESCRIPTION
## Summary

- Convert all math delimiters from MathJax-only `\(...\)`/`\[...\]` to GitHub-compatible `$...$`/`$$...$$` in both EN and PT-BR articles — equations now render natively on GitHub while remaining compatible with MkDocs
- Expand Section 6 ("From agreement to disagreement") with a full worked example of coincidence matrix construction (3 items, 3 raters, step-by-step), closing the narrative gap between Kappa limitations and Alpha's definition
- Expand PT-BR article: full experiment descriptions (8.1–8.4), conclusion matching EN depth, complete reference list with DOIs replacing placeholder
- Update export script: automatic YAML frontmatter stripping + `--lang` flag for EN/PT-BR export

## Changes

### Math rendering
- `article/krippendorff-alpha.md` — ~117 inline + 12 display math blocks converted
- `article/krippendorff-alpha.pt-BR.md` — ~44 inline + 10 display math blocks converted
- `mkdocs_docs/javascripts/mathjax.js` — added `$`/`$$` delimiters (backward-compatible)

### Content review (EN)
- Removed internal meta-paragraphs ("Figures.", "Review note (Phase 5)", draft line)
- Expanded Section 6 from ~12 to ~50 lines with worked coincidence matrix example
- Added transition sentences between Sections 3→4 and 7→8
- Added DOIs to all references + Krippendorff (2011) as ref #7

### Content review (PT-BR)
- Removed meta-paragraphs ("Figuras", "Anotações", "Nota de revisão", draft line)
- Expanded Section 6 mirroring EN worked example
- Expanded experiments 8.1–8.4 from 2–3 lines to full paragraphs + added §8.5 (Síntese)
- Expanded conclusion from 1 to 3 paragraphs
- Replaced reference placeholder with complete list including DOIs

### Export script (`scripts/export_article_for_portfolio.py`)
- Strips YAML frontmatter automatically
- New `--lang` flag (`en` | `pt-BR`)
- Output filename matches source article name

## Test plan

- [ ] Open both `.md` files on GitHub and verify math equations render correctly
- [ ] Run `mkdocs build --strict` — passes without warnings
- [ ] Run `python scripts/export_article_for_portfolio.py` — outputs EN bundle with 6 PNGs, no frontmatter
- [ ] Run `python scripts/export_article_for_portfolio.py --lang pt-BR --out dist/pt` — outputs PT-BR bundle
- [ ] Read Sections 5 → 6 → 7 sequentially to verify narrative flow after expansion