### PR TITLE
fix(article): GitHub math rendering, critical review, and export improvements

### DIFF
--- a/article/krippendorff-alpha.md
+++ b/article/krippendorff-alpha.md
@@ -70,10 +70,7 @@ Fix an item $i$. Let $S_i$ be the set of unordered rater pairs $(j,\ell)$, $j<\e
 The **observed agreement** is the fraction of comparable pairs that agree:
 
 $$
-A_o
-=
-\frac{\displaystyle\sum_{i=1}^n \sum_{(j,\ell)\in S_i} I_{ij\ell}}
-     {\displaystyle\sum_{i=1}^n |S_i|}.
+A_o = \frac{\displaystyle\sum_{i=1}^n \sum_{(j,\ell)\in S_i} I_{ij\ell}}{\displaystyle\sum_{i=1}^n |S_i|}.
 $$
 
 So $A_o$ is a **sample proportion** of agreeing pairs, pooled over items. It estimates the probability that two randomly drawn **observed** ratings on the **same** item match, under the implicit design that weights each eligible pair equally.
@@ -107,11 +104,7 @@ Hence the framing: treat $A_o$ as an **estimator** of overlap under your samplin
 **Model.** Two annotators assign labels **independently**, each following the same category distribution $\pi = (\pi_1,\ldots,\pi_K)$, $\pi_k \ge 0$, $\sum_k \pi_k = 1$. Then
 
 $$
-A_e
-=
-P(\text{both pick the same category})
-=
-\sum_{k=1}^K \pi_k^2.
+A_e = P(\text{both pick the same category}) = \sum_{k=1}^K \pi_k^2.
 $$
 
 For **uniform** $\pi_k = 1/K$, we get $A_e = K \cdot (1/K)^2 = 1/K$. With $K=2$, independent coin-flip labellers agree half the time **with no shared truth**. With $K=3$, $A_e = 1/3$.

--- a/article/krippendorff-alpha.pt-BR.md
+++ b/article/krippendorff-alpha.pt-BR.md
@@ -67,10 +67,7 @@ Fixe um item $i$. Seja $S_i$ o conjunto de pares não ordenados $(j,\ell)$, $j<\
 O **acordo observado** é a fração de pares comparáveis em acordo:
 
 $$
-A_o
-=
-\frac{\displaystyle\sum_{i=1}^n \sum_{(j,\ell)\in S_i} I_{ij\ell}}
-     {\displaystyle\sum_{i=1}^n |S_i|}.
+A_o = \frac{\displaystyle\sum_{i=1}^n \sum_{(j,\ell)\in S_i} I_{ij\ell}}{\displaystyle\sum_{i=1}^n |S_i|}.
 $$
 
 Assim $A_o$ é uma **proporção amostral** de pares concordantes, agregada pelos itens.
@@ -102,11 +99,7 @@ Como qualquer proporção, $A_o$ tem **variabilidade amostral**; nos experimento
 **Modelo.** Dois anotadores etiquetam **independentemente**, cada um com a mesma distribuição $\pi=(\pi_1,\ldots,\pi_K)$. Então
 
 $$
-A_e
-=
-P(\text{ambos na mesma categoria})
-=
-\sum_{k=1}^K \pi_k^2.
+A_e = P(\text{ambos na mesma categoria}) = \sum_{k=1}^K \pi_k^2.
 $$
 
 Se $\pi_k=1/K$, $A_e=1/K$. Para $K=2$, “moedas” independentes concordam metade do tempo **sem** verdade partilhada.


### PR DESCRIPTION
## Summary

- Convert all math delimiters from MathJax-only `\(...\)`/`\[...\]` to GitHub-compatible `$...$`/`$$...$$` in both EN and PT-BR articles — equations now render natively on GitHub while remaining compatible with MkDocs
- Expand Section 6 ("From agreement to disagreement") with a full worked example of coincidence matrix construction (3 items, 3 raters, step-by-step), closing the narrative gap between Kappa limitations and Alpha's definition
- Expand PT-BR article: full experiment descriptions (8.1–8.4), conclusion matching EN depth, complete reference list with DOIs replacing placeholder
- Update export script: automatic YAML frontmatter stripping + `--lang` flag for EN/PT-BR export

## Changes

### Math rendering
- `article/krippendorff-alpha.md` — ~117 inline + 12 display math blocks converted
- `article/krippendorff-alpha.pt-BR.md` — ~44 inline + 10 display math blocks converted
- `mkdocs_docs/javascripts/mathjax.js` — added `$`/`$$` delimiters (backward-compatible)

### Content review (EN)
- Removed internal meta-paragraphs ("Figures.", "Review note (Phase 5)", draft line)
- Expanded Section 6 from ~12 to ~50 lines with worked coincidence matrix example
- Added transition sentences between Sections 3→4 and 7→8
- Added DOIs to all references + Krippendorff (2011) as ref #7

### Content review (PT-BR)
- Removed meta-paragraphs ("Figuras", "Anotações", "Nota de revisão", draft line)
- Expanded Section 6 mirroring EN worked example
- Expanded experiments 8.1–8.4 from 2–3 lines to full paragraphs + added §8.5 (Síntese)
- Expanded conclusion from 1 to 3 paragraphs
- Replaced reference placeholder with complete list including DOIs

### Export script (`scripts/export_article_for_portfolio.py`)
- Strips YAML frontmatter automatically
- New `--lang` flag (`en` | `pt-BR`)
- Output filename matches source article name

## Test plan

- [ ] Open both `.md` files on GitHub and verify math equations render correctly
- [ ] Run `mkdocs build --strict` — passes without warnings
- [ ] Run `python scripts/export_article_for_portfolio.py` — outputs EN bundle with 6 PNGs, no frontmatter
- [ ] Run `python scripts/export_article_for_portfolio.py --lang pt-BR --out dist/pt` — outputs PT-BR bundle
- [ ] Read Sections 5 → 6 → 7 sequentially to verify narrative flow after expansion

