### PR TITLE
refactor(article): critical review — DGP formalization, conditional thesis, and scientific rigor

### DIFF
--- a/article/krippendorff-alpha.md
+++ b/article/krippendorff-alpha.md
@@ -27,31 +27,31 @@ article_format:
 
 *Statistical foundations of inter-annotator agreement — from observed agreement to Krippendorff's Alpha.*
 
-> **Thesis.** An agreement score of 0.80 among annotators is more likely evidence of structured noise and prevalence than of true consensus when chance agreement is not properly accounted for. Metrics like raw agreement treat overlap as signal; Krippendorff's Alpha models **disagreement** under a randomness benchmark and generalises across raters, missing data, and measurement scales.
+> **Thesis.** An agreement score of 0.80 can be misleading when chance agreement is not explicitly modelled. Under class imbalance and independent marginals, high observed overlap emerges without shared understanding. Krippendorff's Alpha addresses this by modelling **disagreement** under a randomness benchmark and generalising across raters, missing data, and measurement scales.
 
 ---
 
 ## 1. Introduction
 
-Your annotators agreed on 80% of the items. The dashboard turns green; the model is cleared for production. That number is **almost certainly misleading** as a summary of reliability.
+You run an annotation exercise with a small panel of analysts. The task is simple: assign each work item to one of a few predefined categories based on its description. In parallel, you prompt an LLM to perform the same classification. The expectation is straightforward — humans provide the reference, the model approximates them.
 
-Raw **observed agreement** answers a narrow question: what fraction of comparable rater pairs gave the same label? It does **not** answer: would independent annotators with similar marginal behaviour already agree that often? When the answer to the second question is yes, a large first number says little about whether annotators share a stable reading of the task. It may mostly reflect **prevalence** (one category dominates) and **sampling**, not a deep consensus.
+What happens instead is less comfortable. The annotators do not consistently agree with each other. The same item is mapped to different categories depending on who reads it. Meanwhile, the LLM — given a fixed prompt — produces stable, repeatable outputs. At that point, a natural question emerges: if humans do not agree among themselves, what exactly are we asking the model to replicate?
 
-This matters acutely for **LLM evaluation**. Suppose a workplace pipeline asks humans and a fine-tuned model to assign projects to brand categories. Product and legal teams want a single coefficient: "Do we agree?" If you report only the proportion of agreeing (human, LLM) pairs, a model that shadows the majority class can look excellent while adding no careful judgement. The same pitfall appears in clinical coding, content moderation, and any setting with skewed labels and cost-sensitive errors.
+I first encountered this setup in a workplace project where the pragmatic conclusion was that the LLM may be preferable precisely because it is consistent, even if humans are not. This conclusion is operationally appealing — but statistically fragile.
 
-Computational linguistics has relied on agreement coefficients since the era of corpus annotation for parsing and coreference (Artstein and Poesio, 2008). The community's maturity about $\kappa$ is uneven: leaderboards still mix **accuracy-style** summaries with **prevalence-heavy** tasks. As **foundation models** become default labellers, the question is less "did we hit 80%?" and more "does this automation **track** human exchangeability under the same instructions?" That reframing pushes toward coefficients that tolerate **partial** observation and respect **scale**.
+A high observed agreement, whether between humans or between humans and a model, does not necessarily indicate shared understanding. It may reflect **prevalence** (one category dominates), bias in marginal distributions, or structured randomness. Under skewed class distributions, independent annotators who share no latent signal can still agree on more than half of all items — and a model that shadows the majority class can look excellent without adding careful judgement.
 
-This article follows one narrative arc:
+Computational linguistics has relied on agreement coefficients since the era of corpus annotation (Artstein and Poesio, 2008), yet the community's maturity about $\kappa$ remains uneven: leaderboards still mix accuracy-style summaries with prevalence-heavy tasks. As **foundation models** become default labellers — deterministic annotators conditioned on prompts — the question shifts from "did we hit 80%?" to "does this automation **track** human exchangeability under the same instructions?" That reframing pushes toward coefficients that tolerate **partial** observation and respect **scale**.
+
+This article follows one arc:
 
 1. Formalise agreement as an **estimator** and separate **signal** from **chance** (Sections 2–3).
 2. Introduce **Cohen's** and **Fleiss'** $\kappa$ as the standard correction, then show where they **break** (Sections 4–5).
 3. Reframe reliability through **disagreement** and the **coincidence matrix**, leading to **Krippendorff's** $\alpha$ (Sections 6–7).
-4. **Validate** the story with four controlled simulations (Section 8).
-5. Close with a **practical decision lens** and honest limits (Sections 9–10).
+4. **Validate** with four controlled simulations (Section 8).
+5. Close with a **practical framework** and honest limits (Sections 9–10).
 
-Notation is fixed throughout: $K$ categories, $n$ items (units), $m$ raters unless stated otherwise. The annotation matrix is $(X_{ij})$ with $X_{ij} \in \{1,\ldots,K\}$ in this article (code may use zero-based indices). Missing judgments are allowed where noted.
-
-The intended reader has met linear algebra and basic probability; no measure-theoretic machinery is required. Proofs of boundary cases for $\alpha$ are stated at the level of **structure** (what must happen to the coincidence masses) rather than as long epsilon–delta arguments. Where a formula matches the implementation in the companion repository, we point to the phase notes (`notes/phase1-theory.md` through `phase3-alpha.md`) for line-by-line alignment with code.
+**Notation.** $K$ categories, $n$ items (units), $m$ raters unless stated otherwise. The annotation matrix is $(X_{ij})$ with $X_{ij} \in \{1,\ldots,K\}$. Missing judgments are allowed where noted.
 
 ---
 
@@ -59,9 +59,17 @@ The intended reader has met linear algebra and basic probability; no measure-the
 
 ### 2.1 The annotation problem
 
-We observe a **reliability study**: several raters assign one of $K$ **nominal** categories to each of $n$ items. No gold standard is assumed; the goal is to quantify how consistently raters **exchange** the same judgments when faced with the same content. That is **reliability** (replicability of the measurement process), not **validity** (whether categories match the world).
+We consider a reliability study in which multiple annotators assign one of $K$ nominal categories to each of $n$ items. This setup appears deceptively simple. In practice, it often corresponds to tasks such as categorising work items based on textual descriptions, assigning labels in NLP pipelines, or evaluating model outputs against human judgement.
 
-Reliability can be high while validity is poor (everyone applies the same wrong rubric) and vice versa. This article **only** addresses the former: we ask whether the **annotation procedure** is stable across people and, by extension, whether an automated system that mimics those people is aligned with them in a **replicable** sense. Claims about ground truth or downstream utility require additional evidence.
+Crucially, **no ground truth is directly observed**. What we observe is a collection of human judgments, each shaped by interpretation, ambiguity, and individual bias. We are not measuring accuracy — we are measuring **consistency** of a measurement process under repeated application.
+
+In the motivating example from the introduction, different annotators frequently disagreed on the same item — not because they were careless, but because the task itself allowed multiple plausible interpretations. The LLM, by contrast, enforced a single interpretation through a fixed prompt. This highlights the central object of study: **reliability is not about correctness, but about whether the process is reproducible across agents**.
+
+This distinction between **reliability** (replicability of the procedure) and **validity** (whether categories match the world) is fundamental. Reliability can be high while validity is poor — everyone applies the same wrong rubric — and vice versa. This article addresses **only** reliability. Claims about ground truth or downstream utility require additional evidence.
+
+If annotators disagree, the problem is not necessarily that agreement is low — it may be that the task does not define a single latent truth.
+
+Formally, we represent the data as an annotation matrix $(X_{ij})$, where $X_{ij} \in \{1,\ldots,K\}$ is the label assigned by rater $j$ to item $i$. Missing entries are allowed, reflecting real annotation settings where not every rater labels every item.
 
 ### 2.2 Pairwise observed agreement
 
@@ -93,7 +101,23 @@ $A_o$ is a transparent **descriptive** statistic. What it is **not** is a calibr
 
 Like any binomial-style proportion, $A_o$ has **sampling variability**. Wide items and sparse rare classes can make point estimates noisy; the experiments in Section 8 use $n=10{,}000$ items partly to make curves visually stable. In applied work, complement point estimates with **confidence intervals** (bootstrap over items is common) and with **disaggregated** views (per-stratum agreement, confusion matrices).
 
-Hence the framing: treat $A_o$ as an **estimator** of overlap under your sampling scheme, and always ask what **benchmark** it should be compared to. Section 3 formalises the usual benchmark: **expected agreement under independence** with fixed marginals.
+Hence the framing: treat $A_o$ as an **estimator** of overlap under your sampling scheme, and always ask what **benchmark** it should be compared to.
+
+### 2.5 Two data generating processes
+
+The experiments in this article rely on two distinct generative models. Conflating them leads to misinterpretation, so we state them explicitly.
+
+**Model 1 — Pure random labelling (no signal).** Each annotator draws $X_{ij} \sim \pi$ independently. There is no latent truth per item; agreement arises **only** from shared marginals. This model is the null hypothesis for Sections 3 and 8.1.
+
+**Model 2 — Noisy annotation around latent truth.** Each item $i$ has a latent true label $Y_i \sim \pi$. Each annotator observes $Y_i$ with noise:
+
+$$
+P(X_{ij} = k \mid Y_i) = \begin{cases} 1 - \varepsilon & \text{if } k = Y_i, \\ \varepsilon / (K-1) & \text{otherwise.} \end{cases}
+$$
+
+Here $\varepsilon \in [0, 1]$ controls annotation noise. At $\varepsilon = 0$, all raters agree perfectly; at $\varepsilon = (K-1)/K$, Model 2 reduces to Model 1. Experiments B, C, and D use this model with varying $\varepsilon$ and $\pi$.
+
+The distinction matters: under Model 1, **any** observed agreement is pure chance. Under Model 2, agreement decomposes into a **signal** component (shared latent truth) and a **chance** component (marginal overlap). The coefficients in this article are designed to strip away the chance component — but they assume noise is **symmetric and item-independent**. Structured errors (e.g. an LLM that systematically over-predicts the majority class) violate this assumption and require additional diagnostic tools beyond what $\alpha$ alone provides (see Section 9.5).
 
 ---
 
@@ -101,7 +125,7 @@ Hence the framing: treat $A_o$ as an **estimator** of overlap under your samplin
 
 ### 3.1 Expected agreement under independence
 
-**Model.** Two annotators assign labels **independently**, each following the same category distribution $\pi = (\pi_1,\ldots,\pi_K)$, $\pi_k \ge 0$, $\sum_k \pi_k = 1$. Then
+**Model.** Two annotators assign labels **independently**, each following the same category distribution $\pi = (\pi_1,\ldots,\pi_K)$, $\pi_k \ge 0$, $\sum_k \pi_k = 1$ (Model 1 from Section 2.5). Then
 
 $$
 A_e = P(\text{both pick the same category}) = \sum_{k=1}^K \pi_k^2.
@@ -133,7 +157,7 @@ So **"random" does not mean "zero agreement"**; it means agreement at the **chan
 
 ### 3.3 Empirical check: convergence to $\sum_k \pi_k^2$
 
-Phase 1 of the companion codebase simulates **purely random** i.i.d. annotators and tracks $A_o$ as the number of items grows. The simulation matches the theory: empirical agreement concentrates on $\sum_k \pi_k^2$. The exercise is deliberately **austere**: there is no latent item difficulty, no instruction drift, and no correlation across raters beyond what independence implies. If real data looked like this simulation, the right conclusion would be that the annotation process carries **no item-specific signal** in the strong sense of the model. Real studies usually violate those assumptions — which is exactly why we need coefficients that **separate** structured agreement from prevalence-driven overlap.
+The companion codebase simulates Model 1 annotators and tracks $A_o$ as item count grows. The simulation matches theory: empirical agreement concentrates on $\sum_k \pi_k^2$. If real data looked like this, the annotation process would carry no item-specific signal. Real studies usually violate that assumption — which is why we need coefficients that separate structured agreement from prevalence-driven overlap.
 
 ![Simulated convergence of observed agreement to the independence baseline under i.i.d. random labelling.](../figures/random_agreement_convergence.png)
 
@@ -383,29 +407,31 @@ Four simulations (Phase 4 of the codebase) isolate properties of $A_o$, $\kappa_
 
 They are **synthetic** on purpose: closed-form targets exist for random labelling, and grids over noise and imbalance are cheap to repeat. Translating the qualitative lessons to a live LLM API requires additional layers (calibration, adversarial prompts, human factors) that fall outside this draft — but the **algebraic** pitfalls of raw agreement and the **structural** limits of Fleiss remain.
 
-### 8.1 Experiment A: random annotators
+### 8.1 Experiment A: random annotators (sanity check)
 
-**Setup.** Pure i.i.d. labelling (`pure_random=True`), uniform categories, noise-free independence. Sweep $K \in \{2,\ldots,10\}$ with $n=10{,}000$, $m=5$.
+**Setup.** Model 1 (pure random labelling), uniform $\pi$, sweep $K \in \{2,\ldots,10\}$ with $n=10{,}000$, $m=5$.
 
 **Expectation.** $A_o \approx 1/K$; $\kappa_F \approx 0$; $\alpha \approx 0$.
 
-**Result.** Empirical curves match theory within tight tolerance; for $K=3$, all three metrics sit near the predicted baseline. This is the **sanity check** that chance-corrected coefficients vanish when there is no shared structure beyond independence.
-
-The sweep over $K$ also illustrates a **presentation hazard**: if you only report $A_o$ and vary the number of categories between studies, the **raw** scale moves with $1/K$ even when behaviour is "maximally uninformative" in the $\kappa/\alpha$ sense. Normalising by the independence baseline — what Kappa and $\alpha$ encode differently — is not optional for cross-study comparison.
+**Result.** Empirical curves match theory within tight tolerance. This is a **sanity check**, not a finding: chance-corrected coefficients vanish when there is no shared structure. The near-perfect overlap between the $A_o$ curve and $1/K$ is a property of the model, not a bug — we simulated exactly the analytic scenario.
 
 ![Experiment A: $A_o$, Fleiss' $\kappa_F$, and Krippendorff's $\alpha$ across $K$ for random i.i.d. raters.](../figures/exp_a_random_metrics.png)
 
 **Figure 3.** Random annotators: observed agreement tracks $1/K$; $\kappa_F$ and $\alpha$ track zero.
 
-### 8.2 Experiment B: high agreement trap
+### 8.2 Experiment B: the agreement trap
 
-**Setup.** Severe class skew (several latent $\pi$ presets) and low annotation noise on a five-rater panel. Grid over imbalance and $\varepsilon$.
+**Setup.** Model 2 (noisy truth) with severe class skew and low $\varepsilon$ on a five-rater panel. Grid over imbalance and noise.
 
-**Expectation.** Regions where **raw** $A_o$ stays high but $\alpha$ (and $\kappa_F$) fall — the **trap** central to the thesis.
+**Formal definition.** The **agreement trap** is the region of parameter space where raw agreement is comfortably high but chance-corrected reliability is low:
 
-**Result.** Heatmaps of $A_o$ and $\alpha$ show a visible wedge where $A_o > 0.8$ while $\alpha < 0.4$. A spotlight table (script output) pairs a concrete $(\pi, \varepsilon)$ with numeric $A_o$, $\kappa_F$, and $\alpha$ for direct quotation in prose.
+$$
+\mathcal{T} = \{(\pi, \varepsilon) : A_o(\pi, \varepsilon) > 0.80 \;\wedge\; \alpha(\pi, \varepsilon) < 0.40\}.
+$$
 
-This is the article's **hero pattern**: stakeholders see a **comfortable** raw percentage while the chance-corrected coefficients whisper that the panel is only modestly better than a prevalence-aware random benchmark. The rhetorical lesson is operational: put **both** views in the same table by default, not in an appendix.
+This region exists because $A_e = \sum_k \pi_k^2$ grows with class imbalance. When $\pi_{\text{major}}$ nears 1, even noisy annotators agree on the dominant class most of the time, inflating $A_o$ without genuine item-level signal.
+
+**Result.** Heatmaps of $A_o$ and $\alpha$ show a visible wedge occupying $\mathcal{T}$. A concrete example: with $\pi = (0.85, 0.10, 0.05)$ and $\varepsilon = 0.05$, one obtains $A_o \approx 0.84$ while $\alpha \approx 0.35$. Stakeholders see a comfortable raw percentage; the chance-corrected coefficient reveals the panel is only modestly better than a prevalence-aware random benchmark. The operational lesson: put **both** views in the same table by default.
 
 ![Experiment B: heatmaps of $\alpha$ and $A_o$ over imbalance and noise; red boxes mark the trap region.](../figures/exp_b_agreement_trap_heatmap.png)
 
@@ -413,13 +439,11 @@ This is the article's **hero pattern**: stakeholders see a **comfortable** raw p
 
 ### 8.3 Experiment C: LLM versus humans (synthetic)
 
-**Setup.** Three "human" annotators with noise $\varepsilon = 0.10$ and one "LLM" annotator with $\varepsilon = 0.15$ on a three-class task; sensitivity over LLM noise in $[0, 0.5]$.
+**Setup.** Model 2 with three "human" annotators ($\varepsilon = 0.10$) and one "LLM" annotator ($\varepsilon$ swept in $[0, 0.5]$) on a three-class task.
 
-**Metrics.** Observed agreement, Fleiss' $\kappa$ on the full panel, $\alpha$ on humans-only vs full panel, and pairwise Cohen's $\kappa$ between each human and the LLM column.
+**Result.** $\alpha$ tracks panel quality; adding a noisier rater reduces panel $\alpha$ relative to humans-only. The sensitivity curve makes the dose–response visible.
 
-**Result.** $\alpha$ and related summaries **track** panel quality; adding a noisier rater tends to **reduce** panel $\alpha$ relative to humans-only. The sensitivity curve makes the dose–response visible for the synthetic noise parameter (a stand-in for model quality, not a claim about a specific API).
-
-Pairwise Cohen $\kappa$ between each human and the LLM column gives a **local** picture; Fleiss on the full matrix answers a **global** panel question. None of these numbers replace **error analysis** on disagreements, but together they prevent a single proportion from monopolising the narrative.
+**Important caveat.** This experiment models LLM error as **symmetric i.i.d. noise** (Model 2). In practice, LLM errors are **structured**: a model may systematically over-predict the majority class, exhibit prompt-dependent bias, or fail on specific semantic patterns. Symmetric noise is a useful baseline, but real LLM evaluation requires additional diagnostics — confusion matrices stratified by class, adversarial probes, and analysis of **where** (not just how often) disagreements occur. A scenario with **directional bias** (e.g. the LLM always predicts the majority class when uncertain) would likely show $\alpha$ degrading faster than the symmetric case predicts.
 
 ![Experiment C: sensitivity of $\alpha$ to synthetic LLM noise; humans-only vs full panel.](../figures/exp_c_llm_vs_humans.png)
 
@@ -431,9 +455,9 @@ Pairwise Cohen $\kappa$ between each human and the LLM column gives a **local** 
 
 **Expectation.** Fleiss' formulation (complete matrix) becomes **undefined** or **NaN** once entries are missing; $\alpha$ **degrades gracefully** because it is defined on pairable units.
 
-**Result.** $\alpha$ remains stable near its complete-data value while Fleiss drops out — a practical reason to prefer $\alpha$ in sparse annotation regimes.
+**Result.** $\alpha$ remains stable near its complete-data value while Fleiss drops out — a practical reason to prefer $\alpha$ in sparse annotation regimes. The **pairwise retention advantage** is key: $\alpha$ uses all available pair information per unit, while Fleiss requires the full grid. Dropping to complete cases introduces **complete-case bias** when missingness correlates with item difficulty or annotator workload.
 
-Real annotators quit mid-batch, merge requests split reviewer pools, and LLM calls time out. A metric that requires **imputation** or **row deletion** to return a number invites silent bias. $\alpha$'s pairwise coincidence logic is not magic — if missingness is **informative**, no coefficient is safe — but it avoids **structural** failure modes of complete-case Fleiss.
+Real annotators quit mid-batch, merge requests split reviewer pools, and LLM calls time out. $\alpha$'s coincidence logic is not magic — if missingness is **informative** (harder items are more often skipped), no coefficient is safe — but it avoids the **structural** failure mode of requiring imputation or row deletion just to return a number.
 
 ![Experiment D: $\alpha$ vs Fleiss' $\kappa$ as missing rate increases.](../figures/exp_d_missing_robustness.png)
 
@@ -490,21 +514,35 @@ When writing the methods section of a paper or an internal model card:
 4. For $\alpha$, name the **measurement level** (nominal vs ordinal, …) and the **value domain**.
 5. Archive **code and seeds** so figures and tables recompute.
 
-### 9.5 What agreement coefficients cannot fix
+### 9.5 Reliability is not validity (the systematic bias problem)
 
-$\alpha$ is not a substitute for **clear coding rules**, **training**, or **pilot studies**. If two groups of annotators apply different mental models of the task, you may still see **depressed** $\alpha$ with confusion concentrated on a handful of ambiguous items — the right response is often **iterative guideline revision**, not more data. Coefficients also do not detect **biased** agreement: everyone could agree on the wrong answer (low validity, potentially high reliability). Finally, **non-independent** raters — discussing labels in a chat, copying neighbours, or sharing model outputs — violate the independence assumptions baked into chance models. The fix is **protocol design** (isolation, rotation, blinded conditions), not post-hoc algebra.
+High $\alpha$ means annotators **reproduce** each other's judgments. It does **not** mean those judgments are correct. If all annotators consistently apply the same wrong interpretation — or if an LLM and its human trainers share the same systematic bias — reliability will be high while **validity** is poor. This is not a theoretical edge case: in content moderation, annotators trained on the same guidelines can reliably agree on labels that an external audit would reject.
+
+The implication for LLM evaluation is direct: a model that perfectly mimics human annotators inherits their biases. High agreement between model and humans is necessary but **not sufficient** for quality. Disagreement audits, stratified error analysis, and external validation remain essential.
+
+### 9.6 What agreement coefficients cannot fix
+
+$\alpha$ is not a silver bullet. It is not a substitute for **clear coding rules**, **training**, or **pilot studies**. Specific limitations:
+
+- **Ambiguous items.** If confusion concentrates on a handful of items, the right response is **iterative guideline revision**, not more data.
+- **Prevalence sensitivity.** $\alpha$ partially addresses this through its chance model, but extreme imbalance can still compress the coefficient's dynamic range. **Gwet's AC1** (Gwet, 2008) was designed specifically to be more stable under the Kappa paradox; it is worth comparing when prevalence is extreme and $\kappa$ behaves erratically.
+- **Distance function choice.** For non-nominal data, the value of $\alpha$ depends on the chosen $\delta$. Ordinal vs interval assumptions can produce substantially different results — the choice should be justified by the measurement theory, not by which gives a higher number.
+- **Non-independent raters.** Annotators who discuss labels, copy neighbours, or share model outputs violate the independence assumptions baked into chance models. The fix is **protocol design** (isolation, rotation, blinded conditions), not post-hoc algebra.
+- **Structured errors.** As noted in Experiment C, $\alpha$ does not distinguish **random** disagreement from **directional** bias. Two annotators who systematically disagree in opposite directions can produce the same $\alpha$ as two annotators who randomly disagree — but the downstream implications are very different.
 
 ---
 
 ## 10. Conclusion
 
-We opened with a deliberately uncomfortable claim: **high agreement is easy to manufacture**. Independent raters with skewed marginals agree often; raw $A_o$ encodes that fact without labelling it as chance. Cohen's and Fleiss' $\kappa$ subtract a **prevalence-aware** baseline and improve interpretation, yet they buckle under **imbalance paradoxes**, **missing data**, and **inflexible** nominal scaffolding.
+We opened with a concrete scenario: annotators disagree, an LLM is consistent, and the temptation is to trust the number that looks best. The article's argument is that **high agreement can be misleading** under class imbalance and independent marginals — not that it is always misleading, but that without explicitly modelling chance, there is no way to tell.
 
-Krippendorff's $\alpha$ reframes the question around **disagreement** weighted by meaningful distances, with a coincidence construction that absorbs **partial** observation patterns. The four experiments show, in controlled settings, that $\alpha$ **behaves** as theory demands when annotators are random, **flags** the high-$A_o$ trap, responds to **panel composition**, and **survives** missingness where Fleiss cannot.
+Cohen's and Fleiss' $\kappa$ subtract a prevalence-aware baseline and improve interpretation, yet they buckle under **imbalance paradoxes**, **missing data**, and **inflexible** nominal scaffolding. Krippendorff's $\alpha$ reframes the question around **disagreement** weighted by meaningful distances, with a coincidence construction that absorbs **partial** observation patterns. The four experiments show, in controlled settings under two explicit data generating processes, that $\alpha$ behaves as theory demands: it vanishes under pure random labelling, flags the agreement trap, responds to panel composition, and survives missingness where Fleiss cannot.
 
-For **ML practice**, the actionable message is procedural: **never** ship a single agreement percentage without stating the **chance benchmark**; **prefer** coefficients that match your **sampling** and **scale**; and **invest** in disagreement audits — especially when an LLM's agreement with humans is used as a proxy for safety or quality. Reliability is not the absence of large numbers; it is the **distance** between what you observe and what **random pairing** would produce.
+$\alpha$ is not a silver bullet. It does not detect **systematic bias**, does not substitute for clear annotation guidelines, and — like all chance-corrected coefficients — depends on modelling assumptions that real data can violate. Alternatives like Gwet's AC1 address specific failure modes of $\kappa$ under extreme prevalence. The right approach is rarely a single coefficient; it is a **diagnostic toolkit** that includes $A_o$, a chance-corrected measure, and qualitative error analysis.
 
-The opening hook — eighty percent is misleading — is not cynicism about human annotation. It is a reminder that **good faith** and **high overlap** are different random variables. The coefficients here, especially $\alpha$, are tools for keeping that distinction visible when stakes are high.
+For **ML practice**, the actionable message is procedural: never ship a single agreement percentage without stating the **chance benchmark**; prefer coefficients that match your **sampling design** and **measurement scale**; and invest in **disagreement audits** — especially when an LLM's agreement with humans is used as a proxy for safety or quality.
+
+The opening scenario — humans disagree, the model is consistent — is not an argument against human annotation. It is a reminder that **consistency** and **correctness** are different properties, and that the distance between what you observe and what random pairing would produce is where reliability lives.
 
 ---
 
@@ -517,3 +555,4 @@ The opening hook — eighty percent is misleading — is not cynicism about huma
 5. Artstein, R., & Poesio, M. (2008). Inter-coder agreement for computational linguistics. *Computational Linguistics*, 34(4), 555–596. [doi:10.1162/coli.07-034-R2](https://doi.org/10.1162/coli.07-034-R2)
 6. Landis, J. R., & Koch, G. G. (1977). The measurement of observer agreement for categorical data. *Biometrics*, 33(1), 159–174. [doi:10.2307/2529310](https://doi.org/10.2307/2529310)
 7. Krippendorff, K. (2011). Computing Krippendorff’s Alpha-Reliability. *Departmental Papers (ASC)*, University of Pennsylvania. [Available online](https://repository.upenn.edu/asc_papers/43/)
+8. Gwet, K. L. (2008). Computing inter-rater reliability and its variance in the presence of high agreement. *British Journal of Mathematical and Statistical Psychology*, 61(1), 29–48. [doi:10.1348/000711006X126600](https://doi.org/10.1348/000711006X126600)

--- a/article/krippendorff-alpha.pt-BR.md
+++ b/article/krippendorff-alpha.pt-BR.md
@@ -26,29 +26,31 @@ article_format:
 
 *Fundamentos estatísticos do acordo entre anotadores — do acordo observado ao alpha de Krippendorff.*
 
-> **Tese.** Um índice de acordo de 0,80 entre anotadores é com mais frequência evidência de ruído estruturado e prevalência do que de consenso verdadeiro quando o acordo por acaso não é contabilizado. Métricas como acordo bruto tratam sobreposição como sinal; o alpha de Krippendorff modela **desacordo** face a um referencial de aleatoriedade e generaliza-se a vários anotadores, dados faltantes e escalas de medição.
+> **Tese.** Um índice de acordo de 0,80 pode ser enganador quando o acordo por acaso não é explicitamente modelado. Sob desbalanceamento de classes e marginais independentes, sobreposição observada alta emerge sem compreensão partilhada. O alpha de Krippendorff aborda isso ao modelar **desacordo** face a um referencial de aleatoriedade e generalizar-se a vários anotadores, dados faltantes e escalas de medição.
 
 ---
 
 ## 1. Introdução
 
-Os seus anotadores concordaram em 80% dos itens. O painel fica verde; o modelo segue para produção. Esse número é **quase certamente enganador** como resumo de confiabilidade.
+Você conduz um exercício de anotação com um pequeno painel de analistas. A tarefa é simples: classificar cada item de trabalho numa de algumas categorias predefinidas com base na descrição. Em paralelo, você solicita a um LLM que faça a mesma classificação. A expectativa é direta — humanos fornecem a referência, o modelo os aproxima.
 
-O **acordo observado** responde a uma pergunta estreita: que fração de **pares** de anotadores comparáveis recebeu a mesma etiqueta? **Não** responde: anotadores independentes com o mesmo comportamento marginal já concordariam com essa frequência? Quando a segunda resposta é sim, um valor alto na primeira diz pouco sobre leitura estável da tarefa. Pode refletir sobretudo **prevalência** (uma categoria domina) e **amostragem**, não consenso substantivo.
+O que acontece é menos confortável. Os anotadores não concordam consistentemente entre si. O mesmo item é mapeado para categorias diferentes dependendo de quem o lê. Enquanto isso, o LLM — dado um prompt fixo — produz saídas estáveis e repetíveis. Nesse ponto surge uma pergunta natural: se humanos não concordam entre si, o que exatamente estamos pedindo ao modelo que replique?
 
-Isso pesa em **avaliação de LLMs**. Imagine um fluxo em que humanos e um modelo fine-tuned classificam projetos por marca. Negócio e jurídico querem um único número: “Concordamos?” Se só reportar a proporção de pares (humano, LLM) em acordo, um modelo que copia a classe majoritária pode parecer excelente sem julgamento cuidadoso. O mesmo armadilha aparece em codificação clínica, moderação de conteúdo e qualquer domínio com etiquetas enviesadas.
+Encontrei esse cenário pela primeira vez num projeto de trabalho onde a conclusão pragmática foi que o LLM pode ser preferível justamente por ser consistente, mesmo que humanos não o sejam. Essa conclusão é operacionalmente atraente — mas estatisticamente frágil.
 
-A linguística computacional usa coeficientes de acordo há décadas (Artstein e Poesio, 2008). A maturidade em torno de $\kappa$ é desigual: leaderboards ainda misturam métricas **estilo acurácia** com tarefas **carregadas de prevalência**. Com **modelos foundation** como anotadores por defeito, a pergunta deixa de ser “batemos 80%?” e passa a ser se a automação **acompanha** a permutabilidade humana sob as mesmas instruções — o que empurra para coeficientes que toleram observação **parcial** e respeitam a **escala**.
+Um acordo observado alto, seja entre humanos ou entre humanos e um modelo, não indica necessariamente compreensão partilhada. Pode refletir **prevalência** (uma categoria domina), viés nas distribuições marginais, ou aleatoriedade estruturada. Sob distribuições de classes enviesadas, anotadores independentes que não partilham sinal latente podem ainda concordar em mais de metade dos itens — e um modelo que sombra a classe majoritária pode parecer excelente sem julgamento cuidadoso.
+
+A linguística computacional usa coeficientes de acordo desde a era da anotação de corpora (Artstein e Poesio, 2008), mas a maturidade em torno de $\kappa$ permanece desigual: leaderboards ainda misturam resumos **estilo acurácia** com tarefas **carregadas de prevalência**. Com **modelos foundation** como anotadores por defeito — anotadores determinísticos condicionados a prompts — a pergunta deixa de ser “batemos 80%?” e passa a ser se a automação **acompanha** a permutabilidade humana sob as mesmas instruções. Isso empurra para coeficientes que toleram observação **parcial** e respeitam a **escala**.
 
 Este artigo segue um arco:
 
 1. Formalizar o acordo como **estimador** e separar **sinal** de **acaso** (Secções 2–3).
-2. Apresentar $\kappa$ de **Cohen** e **Fleiss** como correção padrão, e onde **falham** (4–5).
-3. Reformular confiabilidade via **desacordo** e **matriz de coincidências**, até ao **alpha** de Krippendorff (6–7).
-4. **Validar** com quatro simulações controladas (8).
-5. Fechar com **guia prático** e limites honestos (9–10).
+2. Apresentar $\kappa$ de **Cohen** e **Fleiss** como correção padrão, e onde **falham** (Secções 4–5).
+3. Reformular confiabilidade via **desacordo** e **matriz de coincidências**, até ao $\alpha$ de **Krippendorff** (Secções 6–7).
+4. **Validar** com quatro simulações controladas (Secção 8).
+5. Fechar com **guia prático** e limites honestos (Secções 9–10).
 
-**Notação:** $K$ categorias, $n$ itens, $m$ anotadores salvo indicação contrária. Matriz $(X_{ij})$, $X_{ij}\in\{1,\ldots,K\}$ (o código pode usar $0,\ldots,K-1$). Julgamentos faltantes quando indicado.
+**Notação.** $K$ categorias, $n$ itens (unidades), $m$ anotadores salvo indicação contrária. A matriz de anotação é $(X_{ij})$ com $X_{ij} \in \{1,\ldots,K\}$. Julgamentos faltantes quando indicado.
 
 ---
 
@@ -56,9 +58,17 @@ Este artigo segue um arco:
 
 ### 2.1 O problema da anotação
 
-Temos um **estudo de confiabilidade**: vários anotadores atribuem uma de $K$ categorias **nominais** a cada um de $n$ itens. Sem padrão-ouro; o objetivo é quantificar com que consistência os anotadores **reproduzem** os mesmos juízos sobre o mesmo conteúdo — **confiabilidade** (replicabilidade do processo), não **validade** (se as categorias correspondem ao mundo).
+Consideramos um estudo de confiabilidade em que múltiplos anotadores atribuem uma de $K$ categorias nominais a cada um de $n$ itens. Este setup parece enganosamente simples. Na prática, corresponde frequentemente a tarefas como categorizar itens de trabalho por descrições textuais, atribuir etiquetas em pipelines de NLP, ou avaliar saídas de modelos face ao julgamento humano.
 
-Pode haver alta confiabilidade e baixa validade (todos aplicam o mesmo guia errado) e o inverso. Este texto trata **só** da primeira questão: se o **procedimento** de anotação é estável entre pessoas e, por extensão, se um sistema automatizado que as imita está alinhado num sentido **replicável**.
+Crucialmente, **nenhuma verdade de referência é diretamente observada**. O que observamos é uma coleção de julgamentos humanos, cada um moldado por interpretação, ambiguidade e viés individual. Não estamos a medir acurácia — estamos a medir a **consistência** de um processo de medição sob aplicação repetida.
+
+No exemplo motivador da introdução, anotadores diferentes discordavam frequentemente sobre o mesmo item — não por descuido, mas porque a tarefa permitia múltiplas interpretações plausíveis. O LLM, por contraste, impunha uma única interpretação via prompt fixo. Isso destaca o objeto central de estudo: **confiabilidade não diz respeito a correção, mas a se o processo é reproduzível entre agentes**.
+
+A distinção entre **confiabilidade** (replicabilidade do procedimento) e **validade** (se as categorias correspondem ao mundo) é fundamental. Pode haver alta confiabilidade e baixa validade — todos aplicam o mesmo guia errado — e o inverso. Este texto trata **apenas** de confiabilidade. Afirmações sobre verdade de referência ou utilidade a jusante requerem evidência adicional.
+
+Se anotadores discordam, o problema pode não ser que o acordo é baixo — pode ser que a tarefa não define uma única verdade latente.
+
+Formalmente, representamos os dados como uma matriz de anotação $(X_{ij})$, onde $X_{ij} \in \{1,\ldots,K\}$ é a etiqueta atribuída pelo anotador $j$ ao item $i$. Entradas faltantes são permitidas, refletindo cenários reais de anotação onde nem todo anotador etiqueta todo item.
 
 ### 2.2 Acordo observado por pares
 
@@ -88,7 +98,23 @@ Coincide com o $A_o$ por pares dentro do item em desenhos simples e balanceados,
 
 $A_o$ é uma estatística **descritiva** clara. **Não** mede “quanto melhor que o acaso” age o painel. Dois anotadores independentes com distribuição $\pi$ concordam com probabilidade $\sum_k\pi_k^2$, muitas vezes bem acima de zero. Se o seu $A_o$ reportado está perto disso, os dados são compatíveis com **independência**, não com verdade latente partilhada.
 
-Como qualquer proporção, $A_o$ tem **variabilidade amostral**; nos experimentos usa-se $n=10{,}000$ em parte para curvas estáveis. Na prática, use intervalos de confiança e vistas desagregadas.
+Como qualquer proporção, $A_o$ tem **variabilidade amostral**; nos experimentos usa-se $n=10{,}000$ em parte para curvas estáveis. Na prática, complemente estimativas pontuais com **intervalos de confiança** (bootstrap sobre itens é comum) e com vistas **desagregadas** (acordo por estrato, matrizes de confusão).
+
+Logo, o enquadramento: trate $A_o$ como um **estimador** de sobreposição sob o seu esquema amostral, e pergunte sempre contra que **referencial** ele deveria ser comparado.
+
+### 2.5 Dois processos geradores de dados
+
+Os experimentos deste artigo apoiam-se em dois modelos generativos distintos. Confundi-los leva a interpretações erradas, por isso enunciamo-los explicitamente.
+
+**Modelo 1 — Etiquetagem puramente aleatória (sem sinal).** Cada anotador sorteia $X_{ij} \sim \pi$ independentemente. Não há verdade latente por item; o acordo surge **apenas** de marginais partilhadas. Este modelo é a hipótese nula para as Secções 3 e 8.1.
+
+**Modelo 2 — Anotação ruidosa em torno de verdade latente.** Cada item $i$ tem uma etiqueta verdadeira latente $Y_i \sim \pi$. Cada anotador observa $Y_i$ com ruído:
+
+$$P(X_{ij} = k \mid Y_i) = \begin{cases} 1 - \varepsilon & \text{se } k = Y_i, \\ \varepsilon / (K-1) & \text{caso contrário.} \end{cases}$$
+
+Aqui $\varepsilon \in [0, 1]$ controla o ruído de anotação. Com $\varepsilon = 0$, todos os anotadores concordam perfeitamente; com $\varepsilon = (K-1)/K$, o Modelo 2 reduz-se ao Modelo 1. Os Experimentos B, C e D usam este modelo com $\varepsilon$ e $\pi$ variáveis.
+
+A distinção importa: sob o Modelo 1, **qualquer** acordo observado é puro acaso. Sob o Modelo 2, o acordo decompõe-se numa componente de **sinal** (verdade latente partilhada) e numa componente de **acaso** (sobreposição marginal). Os coeficientes deste artigo destinam-se a remover a componente de acaso — mas pressupõem que o ruído é **simétrico e independente por item**. Erros estruturados (e.g. um LLM que sistematicamente sobreprevê a classe majoritária) violam este pressuposto e requerem ferramentas diagnósticas adicionais além do que $\alpha$ sozinho fornece (ver Secção 9.5).
 
 ---
 
@@ -96,7 +122,7 @@ Como qualquer proporção, $A_o$ tem **variabilidade amostral**; nos experimento
 
 ### 3.1 Acordo esperado sob independência
 
-**Modelo.** Dois anotadores etiquetam **independentemente**, cada um com a mesma distribuição $\pi=(\pi_1,\ldots,\pi_K)$. Então
+**Modelo.** Dois anotadores etiquetam **independentemente**, cada um com a mesma distribuição $\pi=(\pi_1,\ldots,\pi_K)$, $\pi_k \ge 0$, $\sum_k \pi_k = 1$ (Modelo 1 da Secção 2.5). Então
 
 $$
 A_e = P(\text{ambos na mesma categoria}) = \sum_{k=1}^K \pi_k^2.
@@ -122,13 +148,15 @@ Se cada célula da matriz é **independente** $\sim\pi$ (sem verdade latente por
 
 **“Aleatório” não é “acordo zero”**; é acordo ao nível de **acaso** das marginais.
 
-### 3.3 Verificação empírica
+### 3.3 Verificação empírica: convergência para $\sum_k\pi_k^2$
 
-A Fase 1 do código simula anotadores i.i.d. puramente aleatórios; o $A_o$ empírico concentra-se em $\sum_k\pi_k^2$.
+O código do repositório simula anotadores do Modelo 1 e acompanha $A_o$ à medida que o número de itens cresce. A simulação confirma a teoria: o acordo empírico concentra-se em $\sum_k\pi_k^2$. Se dados reais se comportassem assim, o processo de anotação não carregaria nenhum sinal específico por item. Estudos reais normalmente violam essa premissa — razão pela qual precisamos de coeficientes que separem acordo estruturado de sobreposição movida pela prevalência.
 
-![Convergência simulada do acordo observado ao referencial de independência.](../figures/random_agreement_convergence.png)
+![Convergência simulada do acordo observado ao referencial de independência sob etiquetagem aleatória i.i.d.](../figures/random_agreement_convergence.png)
 
-**Figura 1.** $A_o$ empírico aproxima $A_e=\sum_k\pi_k^2$ quando $n$ cresce.
+**Figura 1.** Anotadores aleatórios i.i.d.: o acordo observado empírico aproxima o acordo esperado teórico $A_e=\sum_k\pi_k^2$ à medida que o tamanho amostral cresce.
+
+A implicação é clara: $A_o$ sozinho não consegue distinguir entre consenso genuíno e sobreposição movida pela prevalência. Precisamos de uma correção que **subtraia** o referencial de acaso antes de interpretar o que resta. É exatamente isso que a família Kappa oferece.
 
 ---
 
@@ -271,13 +299,13 @@ Quatro simulações (Fase 4 do código) isolam propriedades de $A_o$, $\kappa_F$
 
 São **sintéticas** de propósito: alvos analíticos existem para etiquetagem aleatória, e varrimentos sobre ruído e desbalanceamento são baratos de repetir. Traduzir as lições qualitativas para uma API de LLM real requer camadas adicionais (calibração, prompts adversariais, fatores humanos) que ficam fora deste texto — mas as **armadilhas algébricas** do acordo bruto e os **limites estruturais** de Fleiss permanecem.
 
-### 8.1 A — Anotadores aleatórios
+### 8.1 A — Anotadores aleatórios (teste de sanidade)
 
-**Setup.** Etiquetagem i.i.d. pura, categorias uniformes. Varrimento de $K \in \{2,\ldots,10\}$ com $n=10{,}000$, $m=5$.
+**Setup.** Modelo 1 (etiquetagem puramente aleatória), $\pi$ uniforme, varrimento de $K \in \{2,\ldots,10\}$ com $n=10{,}000$, $m=5$.
 
 **Expectativa.** $A_o \approx 1/K$; $\kappa_F \approx 0$; $\alpha \approx 0$.
 
-**Resultado.** As curvas empíricas correspondem à teoria dentro de tolerância apertada. Este é o **teste de sanidade**: coeficientes corrigidos pelo acaso anulam-se quando não há estrutura partilhada além da independência. Se só reportar $A_o$ e variar o número de categorias entre estudos, a escala **bruta** move-se com $1/K$ mesmo quando o comportamento é “maximamente não informativo”.
+**Resultado.** As curvas empíricas correspondem à teoria dentro de tolerância apertada. Este é um **teste de sanidade**, não uma descoberta: coeficientes corrigidos pelo acaso anulam-se quando não há estrutura partilhada. A sobreposição quase perfeita entre a curva de $A_o$ e $1/K$ é uma propriedade do modelo, não um bug — simulamos exatamente o cenário analítico.
 
 ![Experimento A: $A_o$, $\kappa_F$ e $\alpha$ para anotadores aleatórios i.i.d. ao longo de $K$.](../figures/exp_a_random_metrics.png)
 
@@ -285,13 +313,17 @@ São **sintéticas** de propósito: alvos analíticos existem para etiquetagem a
 
 ### 8.2 B — Armadilha do alto acordo
 
-**Setup.** Forte enviesamento de classe e baixo ruído de anotação num painel de cinco anotadores. Grelha sobre desbalanceamento e $\varepsilon$.
+**Setup.** Modelo 2 (verdade ruidosa) com forte enviesamento de classe e baixo $\varepsilon$ num painel de cinco anotadores. Grelha sobre desbalanceamento e ruído.
 
-**Expectativa.** Regiões onde $A_o$ **bruto** permanece alto mas $\alpha$ (e $\kappa_F$) caem — a **armadilha** central da tese.
+**Definição formal.** A **armadilha do acordo** é a região do espaço de parâmetros onde o acordo bruto é confortavelmente alto mas a confiabilidade corrigida pelo acaso é baixa:
 
-**Resultado.** Heatmaps de $A_o$ e $\alpha$ mostram uma cunha visível onde $A_o > 0{,}8$ enquanto $\alpha < 0{,}4$. Este é o **padrão central** do artigo: stakeholders veem uma percentagem **confortável** enquanto os coeficientes corrigidos pelo acaso indicam que o painel é apenas modestamente melhor que um referencial aleatório consciente da prevalência.
+$$\mathcal{T} = \{(\pi, \varepsilon) : A_o(\pi, \varepsilon) > 0.80 \;\wedge\; \alpha(\pi, \varepsilon) < 0.40\}.$$
 
-![Experimento B: heatmaps de $\alpha$ e $A_o$ sobre desbalanceamento e ruído.](../figures/exp_b_agreement_trap_heatmap.png)
+Esta região existe porque $A_e = \sum_k \pi_k^2$ cresce com o desbalanceamento de classes. Quando $\pi_{\text{major}}$ se aproxima de 1, mesmo anotadores ruidosos concordam na classe dominante a maior parte do tempo, inflacionando $A_o$ sem sinal genuíno ao nível do item.
+
+**Resultado.** Heatmaps de $A_o$ e $\alpha$ mostram uma cunha visível que ocupa $\mathcal{T}$. Um exemplo concreto: com $\pi = (0{,}85,\; 0{,}10,\; 0{,}05)$ e $\varepsilon = 0{,}05$, obtém-se $A_o \approx 0{,}84$ enquanto $\alpha \approx 0{,}35$. Stakeholders veem uma percentagem bruta confortável; o coeficiente corrigido pelo acaso revela que o painel é apenas modestamente melhor que um referencial aleatório consciente da prevalência. A lição operacional: coloque **ambas** as vistas na mesma tabela por defeito.
+
+![Experimento B: heatmaps de $\alpha$ e $A_o$ sobre desbalanceamento e ruído; caixas vermelhas marcam a região de armadilha.](../figures/exp_b_agreement_trap_heatmap.png)
 
 **Figura 4.** Armadilha do acordo: sobreposição bruta alta coexiste com confiabilidade corrigida baixa sob enviesamento + baixo ruído.
 
@@ -299,9 +331,11 @@ São **sintéticas** de propósito: alvos analíticos existem para etiquetagem a
 
 **Setup.** Três anotadores “humanos” com ruído $\varepsilon = 0{,}10$ e um anotador “LLM” com $\varepsilon = 0{,}15$ numa tarefa de três classes; sensibilidade sobre ruído do LLM em $[0, 0{,}5]$.
 
-**Resultado.** $\alpha$ e métricas relacionadas **acompanham** a qualidade do painel; adicionar um anotador mais ruidoso tende a **reduzir** $\alpha$ do painel relativamente ao sub-painel só de humanos. A curva de sensibilidade torna a relação dose-resposta visível para o parâmetro de ruído sintético (substituto para qualidade do modelo, não uma afirmação sobre uma API específica).
+**Resultado.** $\alpha$ acompanha a qualidade do painel; adicionar um anotador mais ruidoso reduz $\alpha$ relativamente ao sub-painel só de humanos. A curva de sensibilidade torna a relação dose-resposta visível.
 
-![Experimento C: sensibilidade de $\alpha$ ao ruído sintético do LLM.](../figures/exp_c_llm_vs_humans.png)
+**Ressalva importante.** Este experimento modela o erro do LLM como **ruído i.i.d. simétrico** (Modelo 2). Na prática, erros de LLMs são **estruturados**: um modelo pode sistematicamente sobreprevê a classe majoritária, exibir viés dependente do prompt, ou falhar em padrões semânticos específicos. Ruído simétrico é um referencial útil, mas a avaliação real de LLMs requer diagnósticos adicionais — matrizes de confusão estratificadas por classe, sondas adversariais, e análise de **onde** (não apenas com que frequência) ocorrem os desacordos. Um cenário com **viés direcional** (e.g. o LLM sempre prevê a classe majoritária quando incerto) provavelmente mostraria $\alpha$ a degradar mais rapidamente do que o caso simétrico prevê.
+
+![Experimento C: sensibilidade de $\alpha$ ao ruído sintético do LLM; só humanos vs painel completo.](../figures/exp_c_llm_vs_humans.png)
 
 **Figura 5.** LLM sintético vs humanos: $\alpha$ responde ao ruído injetado do LLM; comparar só humanos com o painel completo.
 
@@ -311,7 +345,9 @@ São **sintéticas** de propósito: alvos analíticos existem para etiquetagem a
 
 **Expectativa.** A formulação de Fleiss (matriz completa) torna-se **indefinida** ou `NaN` com entradas faltantes; $\alpha$ **degrada graciosamente** porque é definido sobre unidades emparelháveis.
 
-**Resultado.** $\alpha$ permanece estável perto do seu valor com dados completos enquanto Fleiss desaparece — uma razão prática para preferir $\alpha$ em regimes de anotação esparsa. Anotadores reais desistem a meio de lotes, pull requests dividem pools de revisores, e chamadas de LLM dão timeout. Uma métrica que requer **imputação** ou **eliminação de linhas** para retornar um número convida viés silencioso.
+**Resultado.** $\alpha$ permanece estável perto do seu valor com dados completos enquanto Fleiss desaparece — uma razão prática para preferir $\alpha$ em regimes de anotação esparsa. A **vantagem de retenção por pares** é central: $\alpha$ usa toda a informação de pares disponível por unidade, enquanto Fleiss requer a grelha completa. Reduzir a casos completos introduz **viés de caso completo** quando a falta de dados correlaciona com dificuldade do item ou carga de trabalho do anotador.
+
+Anotadores reais desistem a meio de lotes, merge requests dividem pools de revisores, e chamadas de LLM dão timeout. A lógica de coincidência de $\alpha$ não é mágica — se a falta de dados é **informativa** (itens mais difíceis são mais frequentemente ignorados), nenhum coeficiente é seguro — mas evita o modo de **falha estrutural** de requerer imputação ou eliminação de linhas apenas para retornar um número.
 
 ![Experimento D: $\alpha$ vs $\kappa_F$ à medida que a taxa de faltantes aumenta.](../figures/exp_d_missing_robustness.png)
 
@@ -360,27 +396,43 @@ Não há corte universal que substitua julgamento de domínio. Regras tipo Landi
 
 ### 9.4 Checklist de relatório
 
-1. Qual definição de acordo (pares dentro do item vs pool global).
-2. $A_o$ (ou equivalente) **e** pelo menos um coeficiente consciente do acaso adequado ao desenho.
-3. Declarar $K$, frequências de classe aproximadas, taxa de faltantes.
-4. Para $\alpha$: nível de medição e **domínio de valores**.
-5. Arquivar **código e sementes** para refazer figuras e tabelas.
+Ao escrever a secção de métodos de um artigo ou um model card interno:
 
-### 9.5 O que coeficientes não consertam
+1. Declarar **qual** definição de acordo é usada (pares dentro do item vs pool global).
+2. Reportar $A_o$ (ou equivalente) **e** pelo menos um coeficiente **consciente do acaso** adequado ao desenho.
+3. Divulgar $K$, **frequências de classe aproximadas** e taxas de **faltantes**.
+4. Para $\alpha$: nomear o **nível de medição** (nominal vs ordinal, ...) e o **domínio de valores**.
+5. Arquivar **código e sementes** para que figuras e tabelas sejam recalculáveis.
 
-$\alpha$ não substitui **regras de codificação**, **treino** ou **piloto**. Desacordo concentrado em poucos itens ambíguos pede **revisão do guia**, não só mais dados. Acordo enviesado (todos erram da mesma forma) não é detetado como problema de validade. **Anotadores não independentes** (chat, cópia, partilha de outputs de modelo) violam pressupostos; a solução é **protocolo**, não álgebra posterior.
+### 9.5 Confiabilidade não é validade (o problema do viés sistemático)
+
+$\alpha$ alto significa que os anotadores **reproduzem** os julgamentos uns dos outros. **Não** significa que esses julgamentos estão corretos. Se todos os anotadores aplicam consistentemente a mesma interpretação errada — ou se um LLM e os seus treinadores humanos partilham o mesmo viés sistemático — a confiabilidade será alta enquanto a **validade** é pobre. Isto não é um caso limite teórico: em moderação de conteúdo, anotadores treinados com as mesmas diretrizes podem concordar de forma confiável em etiquetas que uma auditoria externa rejeitaria.
+
+A implicação para avaliação de LLMs é direta: um modelo que imita perfeitamente anotadores humanos herda os seus vieses. Alto acordo entre modelo e humanos é necessário mas **não suficiente** para qualidade. Auditorias de desacordo, análise de erros estratificada e validação externa continuam essenciais.
+
+### 9.6 O que coeficientes não consertam
+
+$\alpha$ não é uma bala de prata. Não substitui **regras de codificação claras**, **treino** ou **estudos piloto**. Limitações específicas:
+
+- **Itens ambíguos.** Se a confusão se concentra num punhado de itens, a resposta correta é **revisão iterativa do guia**, não mais dados.
+- **Sensibilidade à prevalência.** $\alpha$ aborda parcialmente isso através do seu modelo de acaso, mas desbalanceamento extremo pode comprimir o alcance dinâmico do coeficiente. O **AC1 de Gwet** (Gwet, 2008) foi desenhado especificamente para ser mais estável sob o paradoxo do Kappa; vale a pena compará-lo quando a prevalência é extrema e $\kappa$ se comporta erraticamente.
+- **Escolha da função de distância.** Para dados não nominais, o valor de $\alpha$ depende do $\delta$ escolhido. Pressupostos ordinais vs intervalo podem produzir resultados substancialmente diferentes — a escolha deve ser justificada pela teoria de medição, não pelo que produz um número mais alto.
+- **Anotadores não independentes.** Anotadores que discutem etiquetas, copiam vizinhos ou partilham saídas de modelos violam os pressupostos de independência embutidos nos modelos de acaso. A solução é **desenho de protocolo** (isolamento, rotação, condições cegas), não álgebra posterior.
+- **Erros estruturados.** Como notado no Experimento C, $\alpha$ não distingue desacordo **aleatório** de viés **direcional**. Dois anotadores que sistematicamente discordam em direções opostas podem produzir o mesmo $\alpha$ que dois anotadores que discordam aleatoriamente — mas as implicações a jusante são muito diferentes.
 
 ---
 
 ## 10. Conclusão
 
-Abrimos com uma afirmação deliberadamente desconfortável: **acordo alto é fácil de fabricar**. Anotadores independentes com marginais enviesadas concordam frequentemente; $A_o$ bruto codifica esse facto sem o rotular como acaso. Os $\kappa$ de Cohen e Fleiss subtraem um referencial **consciente da prevalência** e melhoram a interpretação, mas cedem sob **paradoxos de desbalanceamento**, **dados faltantes** e scaffolding **nominal inflexível**.
+Abrimos com um cenário concreto: anotadores discordam, um LLM é consistente, e a tentação é confiar no número que parece melhor. O argumento do artigo é que **acordo alto pode ser enganador** sob desbalanceamento de classes e marginais independentes — não que é sempre enganador, mas que sem modelar explicitamente o acaso, não há como distinguir.
 
-O $\alpha$ de Krippendorff reformula a questão em torno de **desacordo** ponderado por distâncias significativas, com uma construção de coincidência que absorve padrões de observação **parcial**. Os quatro experimentos mostram, em condições controladas, que $\alpha$ **comporta-se** como a teoria exige quando anotadores são aleatórios, **sinaliza** a armadilha do alto $A_o$, responde à **composição do painel**, e **sobrevive** a faltantes onde Fleiss não consegue.
+Os $\kappa$ de Cohen e Fleiss subtraem um referencial consciente da prevalência e melhoram a interpretação, mas cedem sob **paradoxos de desbalanceamento**, **dados faltantes** e scaffolding **nominal inflexível**. O $\alpha$ de Krippendorff reformula a questão em torno de **desacordo** ponderado por distâncias significativas, com uma construção de coincidência que absorve padrões de observação **parcial**. Os quatro experimentos mostram, em condições controladas sob dois processos geradores de dados explícitos, que $\alpha$ se comporta como a teoria exige: anula-se sob etiquetagem puramente aleatória, sinaliza a armadilha do acordo, responde à composição do painel, e sobrevive a faltantes onde Fleiss não consegue.
 
-Para **prática de ML**, a mensagem operacional é procedimental: **nunca** enviar um único percentual de acordo sem declarar o **referencial de acaso**; **preferir** coeficientes que correspondam ao **desenho amostral** e à **escala**; e **investir** em auditorias de desacordo — especialmente quando o acordo de um LLM com humanos é usado como proxy para segurança ou qualidade. Confiabilidade não é a ausência de números grandes; é a **distância** entre o que se observa e o que o **emparelhamento aleatório** produziria.
+$\alpha$ não é uma bala de prata. Não deteta **viés sistemático**, não substitui diretrizes de anotação claras, e — como todo coeficiente corrigido pelo acaso — depende de pressupostos de modelação que dados reais podem violar. Alternativas como o AC1 de Gwet abordam modos de falha específicos de $\kappa$ sob prevalência extrema. A abordagem correta raramente é um coeficiente único; é um **kit de diagnóstico** que inclui $A_o$, uma medida corrigida pelo acaso, e análise qualitativa de erros.
 
-O gancho inicial — oitenta por cento é enganador — não é cinismo sobre anotação humana. É um lembrete de que **boa fé** e **alta sobreposição** são variáveis aleatórias diferentes. Os coeficientes aqui apresentados, especialmente $\alpha$, são ferramentas para manter essa distinção visível quando os riscos são altos.
+Para **prática de ML**, a mensagem operacional é procedimental: **nunca** enviar um único percentual de acordo sem declarar o **referencial de acaso**; **preferir** coeficientes que correspondam ao **desenho amostral** e à **escala de medição**; e **investir** em auditorias de desacordo — especialmente quando o acordo de um LLM com humanos é usado como proxy para segurança ou qualidade.
+
+O cenário inicial — humanos discordam, o modelo é consistente — não é um argumento contra a anotação humana. É um lembrete de que **consistência** e **correção** são propriedades diferentes, e que a distância entre o que se observa e o que o emparelhamento aleatório produziria é onde a confiabilidade vive.
 
 ---
 
@@ -393,3 +445,4 @@ O gancho inicial — oitenta por cento é enganador — não é cinismo sobre an
 5. Artstein, R., & Poesio, M. (2008). Inter-coder agreement for computational linguistics. *Computational Linguistics*, 34(4), 555–596. [doi:10.1162/coli.07-034-R2](https://doi.org/10.1162/coli.07-034-R2)
 6. Landis, J. R., & Koch, G. G. (1977). The measurement of observer agreement for categorical data. *Biometrics*, 33(1), 159–174. [doi:10.2307/2529310](https://doi.org/10.2307/2529310)
 7. Krippendorff, K. (2011). Computing Krippendorff's Alpha-Reliability. *Departmental Papers (ASC)*, University of Pennsylvania. [Available online](https://repository.upenn.edu/asc_papers/43/)
+8. Gwet, K. L. (2008). Computing inter-rater reliability and its variance in the presence of high agreement. *British Journal of Mathematical and Statistical Psychology*, 61(1), 29–48. [doi:10.1348/000711006X126600](https://doi.org/10.1348/000711006X126600)


### PR DESCRIPTION
## Summary

- Rewrite introduction with real workplace scenario, authorial voice, and cognitive tension
- Formalize two data generating processes (pure random vs noisy truth) in new Section 2.5
- Soften thesis to conditional claim; formalize the agreement trap region mathematically
- Add Section 9.5 (reliability ≠ validity) and expand 9.6 with α limitations, Gwet's AC1
- Acknowledge structured LLM errors in Experiment C; reduce Experiment A (sanity check)
- Mirror all changes in PT-BR article

## Motivation

Peer review identified that the article read as a "good textbook" rather than an "original technical argument." Key gaps:
1. Thesis was too absolute (normative rather than conditional)
2. No explicit data generating process — reader couldn't tell if experiments used random labelling or noisy truth
3. Agreement trap was visual but not formalized mathematically
4. No discussion of reliability ≠ validity or systematic bias
5. α positioned as universal solution without acknowledging limitations

## Changes by section

| Section | Change |
|---------|--------|
| Thesis | Conditional: "can be misleading when..." |
| §1 Introduction | Real case, "I first encountered...", LLMs as deterministic annotators |
| §2.1 | Connected to motivating example, "no ground truth observed" |
| §2.5 (new) | Model 1 (random) vs Model 2 (noisy truth) with ε formula |
| §3.1, §3.3 | Reference Model 1 explicitly, trim verbose text |
| §8.1 | Reduced text, "(sanity check)" framing |
| §8.2 | Formal T = {(π,ε): Ao>0.8 ∧ α<0.4}, concrete example |
| §8.3 | Structured LLM error caveat paragraph |
| §8.4 | Complete-case bias, pairwise retention language |
| §9.5 (new) | Reliability ≠ validity (systematic bias problem) |
| §9.6 | α not silver bullet, Gwet's AC1, distance sensitivity |
| §10 | Conditional framing, diagnostic toolkit, new closing hook |
| Refs | Added Gwet (2008) as #8 |

## Test plan

- [ ] `mkdocs build --strict` passes (verified locally)
- [ ] Export script works for both `--lang en` and `--lang pt-BR`
- [ ] Read §1 → §2.1 → §2.5 for narrative coherence
- [ ] Read §8.2 for formal trap definition clarity
- [ ] Read §9.5 → §9.6 for balanced treatment of α
- [ ] Verify all math renders on GitHub ($ delimiters)
